### PR TITLE
More option to lighten bootstrap.php and allow internal ajax requests 

### DIFF
--- a/amp_conf/htdocs/admin/bootstrap.php
+++ b/amp_conf/htdocs/admin/bootstrap.php
@@ -82,12 +82,18 @@ $defaults = array('skip_config' => null,
                   'include_framework_functions' =>true,
                  );
 foreach ($defaults as $key => $default_value) {
-    if (!isset($bootstrap_settings[$key])) $bootstrap_settings[$key] = $default_value;
+    if (!isset($bootstrap_settings[$key])) {
+        $bootstrap_settings[$key] = $default_value;
+    }
 }
 
 // include base functions
-if ($bootstrap_settings['include_compress']) require_once($dirname . '/libraries/compress.class.php');
-if ($bootstrap_settings['include_utility_functions']) require_once($dirname . '/libraries/utility.functions.php');
+if ($bootstrap_settings['include_compress']) {
+    require_once($dirname . '/libraries/compress.class.php');
+}
+if ($bootstrap_settings['include_utility_functions']) {
+    require_once($dirname . '/libraries/utility.functions.php');
+}
 
 $bootstrap_settings['framework_functions_included'] = false;
 if ($bootstrap_settings['include_framework_functions']) {

--- a/amp_conf/htdocs/admin/bootstrap.php
+++ b/amp_conf/htdocs/admin/bootstrap.php
@@ -57,25 +57,36 @@ if (isset($bootstrap_settings['bootstrapped'])) {
   $bootstrap_settings['bootstrapped'] = true;
 }
 
+// Legacy setting methods
 if (!isset($bootstrap_settings['skip_astman'])) {
   $bootstrap_settings['skip_astman'] = isset($skip_astman) ? $skip_astman : false;
 }
-$bootstrap_settings['astman_config'] = isset($bootstrap_settings['astman_config']) ? $bootstrap_settings['astman_config'] : null;
-$bootstrap_settings['astman_options'] = isset($bootstrap_settings['astman_options']) && is_array($bootstrap_settings['astman_options']) ? $bootstrap_settings['astman_options'] : array();
-$bootstrap_settings['astman_events'] = isset($bootstrap_settings['astman_events']) ? $bootstrap_settings['astman_events'] : 'off';
-
-$bootstrap_settings['freepbx_error_handler'] = isset($bootstrap_settings['freepbx_error_handler']) ? $bootstrap_settings['freepbx_error_handler'] : true;
-$bootstrap_settings['freepbx_auth'] = isset($bootstrap_settings['freepbx_auth']) ? $bootstrap_settings['freepbx_auth'] : true;
-$bootstrap_settings['cdrdb'] = isset($bootstrap_settings['cdrdb']) ? $bootstrap_settings['cdrdb'] : false;
-
 $restrict_mods = isset($restrict_mods) ? $restrict_mods : false;
 
+// Set defaults for unset settings
+$defaults = array('skip_config' => null,
+                  'astman_options' => array(),
+                  'astman_events' => 'off',
+                  'freepbx_error_handler' => true,
+                  'freepbx_auth' => true,
+                  'cdrdb' => false,
+                  'include_compress' => true,
+                  'include_utility_functions' => true,
+                  'include_framework_functions' =>true,
+                 );
+foreach ($defaults as $key => $default_value) {
+    if (!isset($bootstrap_settings[$key])) $bootstrap_settings[$key] = $default_value;
+}
+
 // include base functions
-require_once($dirname . '/libraries/compress.class.php');
-require_once($dirname . '/libraries/utility.functions.php');
+if ($bootstrap_settings['include_compress']) require_once($dirname . '/libraries/compress.class.php');
+if ($bootstrap_settings['include_utility_functions']) require_once($dirname . '/libraries/utility.functions.php');
+
 $bootstrap_settings['framework_functions_included'] = false;
-require_once($dirname . '/functions.inc.php');
-$bootstrap_settings['framework_functions_included'] = true;
+if ($bootstrap_settings['include_framework_functions']) {
+   require_once($dirname . '/functions.inc.php');
+   $bootstrap_settings['framework_functions_included'] = true;
+}
 
 //now that its been included, use our own error handler as it tends to be much more verbose.
 if ($bootstrap_settings['freepbx_error_handler']) {

--- a/amp_conf/htdocs/admin/bootstrap.php
+++ b/amp_conf/htdocs/admin/bootstrap.php
@@ -17,6 +17,13 @@
  *
  * bootstrap_settings['freepbx_auth']          - true (default) - authorize, false - bypass authentication
  *
+ * bootstrap_settings['include_compress']      - true (default) - include compress class
+ *
+ * bootstrap_settings['include_utility_functions'] - true (default) - include utility functions.
+ *
+ * bootstrap_settings['include_framework_functions'] - true (default) - include the framework functions which are unavailable elsewhere
+ *
+ *
  * $restrict_mods: false means include all modules functions.inc.php, true skip all modules
  *                 array of hashes means each module where there is a hash
  *                 e.g. $restrict_mods = array('core' => true, 'dashboard' => true)

--- a/amp_conf/htdocs/admin/bootstrap.php
+++ b/amp_conf/htdocs/admin/bootstrap.php
@@ -71,7 +71,7 @@ if (!isset($bootstrap_settings['skip_astman'])) {
 $restrict_mods = isset($restrict_mods) ? $restrict_mods : false;
 
 // Set defaults for unset settings
-$defaults = array('skip_config' => null,
+$bootstrap_defaults = array('skip_config' => null,
                   'astman_options' => array(),
                   'astman_events' => 'off',
                   'freepbx_error_handler' => true,
@@ -81,7 +81,7 @@ $defaults = array('skip_config' => null,
                   'include_utility_functions' => true,
                   'include_framework_functions' =>true,
                  );
-foreach ($defaults as $key => $default_value) {
+foreach ($bootstrap_defaults as $key => $default_value) {
     if (!isset($bootstrap_settings[$key])) {
         $bootstrap_settings[$key] = $default_value;
     }

--- a/amp_conf/htdocs/admin/libraries/BMO/Ajax.class.php
+++ b/amp_conf/htdocs/admin/libraries/BMO/Ajax.class.php
@@ -63,7 +63,6 @@ class Ajax extends FreePBX_Helpers {
 			$this->ajaxError(403, 'ajaxRequest declined');
 		}
 
-		$url = parse_url($_SERVER['HTTP_REFERER']);
 		if($this->settings['allowremote'] !== true) {
 			// Try to avoid CSRF issues.
 			if (!isset($_SERVER['HTTP_REFERER'])) {
@@ -72,6 +71,7 @@ class Ajax extends FreePBX_Helpers {
 
 			// Make sure the url the request is sent to (ie us) is the same host as the referrer
                         // (ie the one which made the page whcih sent us this request).
+                        $url = parse_url($_SERVER['HTTP_REFERER']);
 			if (isset($url['port'])) {
 				$checkhost = $url['host'].":".$url['port'];
 			} else {
@@ -85,11 +85,13 @@ class Ajax extends FreePBX_Helpers {
 
 		session_start();
 
-                // If this is a localhost request (ie this server has sent an ajax request to this server) then
-                // no need to authenticate.
-                if ($url['host'] == '127.0.0.1') $this->settings['authenticate'] = false;
+                // If the request has come from this machine then no need to authenticate.
+                $request_from_ip = $_SERVER['REMOTE_ADDR'];
+                if (($request_from_ip == '127.0.0.1') || ($request_from_ip == '::1')) {
+                    $this->settings['authenticate'] = false;
+                }
 
-                // Check authenticifaction if set to
+                // Check authentication if set to
 		if ($this->settings['authenticate']) {
 			if (!isset($_SESSION['AMP_user'])) {
 				$this->ajaxError(401, 'Not Authenticated');

--- a/amp_conf/htdocs/admin/libraries/BMO/Ajax.class.php
+++ b/amp_conf/htdocs/admin/libraries/BMO/Ajax.class.php
@@ -63,14 +63,15 @@ class Ajax extends FreePBX_Helpers {
 			$this->ajaxError(403, 'ajaxRequest declined');
 		}
 
+		$url = parse_url($_SERVER['HTTP_REFERER']);
 		if($this->settings['allowremote'] !== true) {
 			// Try to avoid CSRF issues.
 			if (!isset($_SERVER['HTTP_REFERER'])) {
 				$this->ajaxError(403, 'ajaxRequest declined - Referrer');
 			}
 
-			// Make sure the referrer is at least this host.
-			$url = parse_url($_SERVER['HTTP_REFERER']);
+			// Make sure the url the request is sent to (ie us) is the same host as the referrer
+                        // (ie the one which made the page whcih sent us this request).
 			if (isset($url['port'])) {
 				$checkhost = $url['host'].":".$url['port'];
 			} else {
@@ -83,6 +84,12 @@ class Ajax extends FreePBX_Helpers {
 		}
 
 		session_start();
+
+                // If this is a localhost request (ie this server has sent an ajax request to this server) then
+                // no need to authenticate.
+                if ($url['host'] == '127.0.0.1') $this->settings['authenticate'] = false;
+
+                // Check authenticifaction if set to
 		if ($this->settings['authenticate']) {
 			if (!isset($_SESSION['AMP_user'])) {
 				$this->ajaxError(401, 'Not Authenticated');


### PR DESCRIPTION
Two proposed changes:

1. Improve and extend the options for bootstrap.php. Rationale: allow modules to speed up initiation time where possible.

2. Allow incoming ajax requests from the server itself (ie localhost to localhost) to proceed without authentication. Rationale: allow modules to issue ajax requests to the system as this may be the most efficient way of getting a the core of a module into action. It may also provide a useful mechanism for other things.