### PR TITLE
Fix undefined index notice on reload

### DIFF
--- a/amp_conf/htdocs/admin/libraries/BMO/ConfigFile.class.php
+++ b/amp_conf/htdocs/admin/libraries/BMO/ConfigFile.class.php
@@ -90,7 +90,7 @@ class ConfigFile {
 
 				$this->config->ProcessedConfig[$section][$key] = array_filter(
 					$this->config->ProcessedConfig[$section][$key],
-					function($v) {global $val; return ($v != $val);}
+					function($v) (use $val) {return ($v != $val);}
 				);
 
 				// Have we deleted everything from that $key?

--- a/amp_conf/htdocs/admin/libraries/BMO/ConfigFile.class.php
+++ b/amp_conf/htdocs/admin/libraries/BMO/ConfigFile.class.php
@@ -88,14 +88,10 @@ class ConfigFile {
 				if ($val == null)
 					throw new \Exception("Sorry, you can't delete an entire section this way, as it's likely a bug");
 
-				// Ok, it's buried in here somewhere. Sigh.
-				foreach ($this->config->ProcessedConfig[$section][$key] as $id => $v) {
-					if ($v == $val) {
-						// Yay, found it.
-						unset($this->config->ProcessedConfig[$section][$key][$id]);
-						// Note, keep going - could be dupes. Don't break here.
-					}
-				}
+				$this->config->ProcessedConfig[$section][$key] = array_filter(
+					$this->config->ProcessedConfig[$section][$key],
+					function($v) {global $val; return ($v != $val);}
+				);
 
 				// Have we deleted everything from that $key?
 				if (count($this->config->ProcessedConfig[$section][$key]) == 0)

--- a/amp_conf/htdocs/admin/libraries/BMO/ConfigFile.class.php
+++ b/amp_conf/htdocs/admin/libraries/BMO/ConfigFile.class.php
@@ -83,25 +83,27 @@ class ConfigFile {
 		if (!isset($this->config->ProcessedConfig[$section]))
 			throw new \Exception("Tried to remove key $key from section $section, but that section doesn't exist");
 
-		if (is_array($this->config->ProcessedConfig[$section][$key])) {
-			if ($val == null)
-				throw new \Exception("Sorry, you can't delete an entire section this way, as it's likely a bug");
+		if (isset($this->config->ProcessedConfig[$section][$key])) {
+			if (is_array($this->config->ProcessedConfig[$section][$key])) {
+				if ($val == null)
+					throw new \Exception("Sorry, you can't delete an entire section this way, as it's likely a bug");
 
-			// Ok, it's buried in here somewhere. Sigh.
-			foreach ($this->config->ProcessedConfig[$section][$key] as $id => $v) {
-				if ($v == $val) {
-					// Yay, found it.
-					unset($this->config->ProcessedConfig[$section][$key][$id]);
-					// Note, keep going - could be dupes. Don't break here.
+				// Ok, it's buried in here somewhere. Sigh.
+				foreach ($this->config->ProcessedConfig[$section][$key] as $id => $v) {
+					if ($v == $val) {
+						// Yay, found it.
+						unset($this->config->ProcessedConfig[$section][$key][$id]);
+						// Note, keep going - could be dupes. Don't break here.
+					}
 				}
-			}
 
-			// Have we deleted everything from that $key?
-			if (count($this->config->ProcessedConfig[$section][$key]) == 0)
+				// Have we deleted everything from that $key?
+				if (count($this->config->ProcessedConfig[$section][$key]) == 0)
+					unset($this->config->ProcessedConfig[$section][$key]);
+			} else {
+				// OK, just one key, easy!
 				unset($this->config->ProcessedConfig[$section][$key]);
-		} else {
-			// OK, just one key, easy!
-			unset($this->config->ProcessedConfig[$section][$key]);
+			}
 		}
 
 		// Is there anything left in that section?

--- a/amp_conf/htdocs/admin/libraries/BMO/ModulesConf.class.php
+++ b/amp_conf/htdocs/admin/libraries/BMO/ModulesConf.class.php
@@ -77,11 +77,11 @@ class ModulesConf {
 
 		if (is_array($module)) {
 			foreach($module as $m) {
-				if (!in_array($m, $current['modules']['preload']))
+				if (!is_array($current['modules']['preload']) || !in_array($m, $current['modules']['preload']))
 					$this->conf->addEntry("modules", "preload=$m");
 			}
 		} else {
-			if (!in_array($module, $current['modules']['preload']))
+			if (!is_array($current['modules']['preload']) || !in_array($module, $current['modules']['preload']))
 				$this->conf->addEntry("modules", "preload=$module");
 		}
 	}
@@ -111,12 +111,12 @@ class ModulesConf {
 
 		if (is_array($module)) {
 			foreach($module as $m) {
-				if (!in_array($m, $current['modules']['load'])) {
+				if (!is_array($current['modules']['load']) || !in_array($m, $current['modules']['load'])) {
 					$this->conf->addEntry("modules", "load=$m");
 				}
 			}
 		} else {
-			if (!in_array($module, $current['modules']['load'])) {
+			if (!is_array($current['modules']['noload']) || !in_array($module, $current['modules']['load'])) {
 				$this->conf->addEntry("modules", "load=$module");
 			}
 		}


### PR DESCRIPTION
Just a quick `isset()` check on the value to ensure it's there before calling `is_array()`. Prevents many dozen "undefined index" notices on each PBX reload.

Second commit just replaces a `foreach` loop with `array_filter()` and is entirely optional! Just caught my eye while I was fixing the other.