### PR TITLE
More fixups for FreeBSD and code refactoring

### DIFF
--- a/amp_conf/bin/freepbx-cron-scheduler.php
+++ b/amp_conf/bin/freepbx-cron-scheduler.php
@@ -62,10 +62,10 @@ if ($email) {
 		if (count($unsigned)) {
 			$send_email = true;
 			$text = $htext;
-			$text .= _("UNSIGNED MODULES NOTICE:")."\n\n";
+			$text .= "\n" . _("UNSIGNED MODULES NOTICE:")."\n\n";
 			foreach ($unsigned as $item) {
-				$text .= $item['display_text']."\n";
-				$text .= $item['extended_text']."\n\n";
+				$text .= $item['display_text'].":\n";
+				$text .= $item['extended_text']."\n";
 			}
 		}
 		$text .= "\n\n";
@@ -89,8 +89,8 @@ if ($email) {
 		$text = $htext . "\n";
 		$text .= _("SECURITY NOTICE:")."\n\n";
 		foreach ($security as $item) {
-			$text .= $item['display_text']."\n";
-			$text .= $item['extended_text']."\n\n";
+			$text .= $item['display_text'].":\n";
+			$text .= $item['extended_text']."\n";
 		}
 	}
 	$text .= "\n\n";

--- a/amp_conf/bin/freepbx-cron-scheduler.php
+++ b/amp_conf/bin/freepbx-cron-scheduler.php
@@ -30,7 +30,7 @@ if(function_exists('sysadmin_get_storage_email')){
 }
 
 //Send email with our mail class
-function chron_scheduler_send_message($to,$from,$subject,$message){
+function cron_scheduler_send_message($to,$from,$subject,$message){
 	$em = new \CI_Email();
 	$em->from($from);
 	$em->to($to);
@@ -72,7 +72,7 @@ if ($email) {
 
 		if ($send_email && (! $cm->check_hash('update_sigemail', $text))) {
 			$cm->save_hash('update_sigemail', $text);
-			if (chron_scheduler_send_message($email, $from_email, sprintf(_("%s: New Unsigned Modules Notifications (%s)"),$brand, $mid), $text)) {
+			if (cron_scheduler_send_message($email, $from_email, sprintf(_("%s: New Unsigned Modules Notifications (%s)"),$brand, $mid), $text)) {
 				$nt->delete('freepbx', 'SIGEMAILFAIL');
 			} else {
 				$nt->add_error('freepbx', 'SIGEMAILFAIL', _('Failed to send unsigned modules notification email'), sprintf(_('An attempt to send email to: %s with unsigned modules notifications failed'),$email));
@@ -97,7 +97,7 @@ if ($email) {
 
 	if ($send_email && (! $cm->check_hash('update_semail', $text))) {
 		$cm->save_hash('update_semail', $text);
-		if (chron_scheduler_send_message($email, $from_email, sprintf(_("%s: New Security Notifications (%s)"),$brand, $mid), $text)) {
+		if (cron_scheduler_send_message($email, $from_email, sprintf(_("%s: New Security Notifications (%s)"),$brand, $mid), $text)) {
 			$nt->delete('freepbx', 'SEMAILFAIL');
 		} else {
 			$nt->add_error('freepbx', 'SEMAILFAIL', _('Failed to send security notification email'), sprintf(_('An attempt to send email to: %s with security notifications failed'),$email));
@@ -120,7 +120,7 @@ if ($email) {
 
 	if ($send_email && (! $cm->check_hash('update_email', $text))) {
 		$cm->save_hash('update_email', $text);
-		if (chron_scheduler_send_message($email, $from_email, sprintf(_("%s: New Online Updates Available (%s)"),$brand,$mid), $text)) {
+		if (cron_scheduler_send_message($email, $from_email, sprintf(_("%s: New Online Updates Available (%s)"),$brand,$mid), $text)) {
 			$nt->delete('freepbx', 'EMAILFAIL');
 		} else {
 			$nt->add_error('freepbx', 'EMAILFAIL', _('Failed to send online update email'), sprintf(_('An attempt to send email to: %s with online update status failed'),$email));

--- a/amp_conf/bin/retrieve_conf
+++ b/amp_conf/bin/retrieve_conf
@@ -933,8 +933,10 @@ function listdir($directory, $recursive=true) {
 	return array_reverse($array_items);//reverse so that we get directories BEFORE the files that are in them
 }
 
-/** Check if there is a job running, if one is found then all is good, if one is not found, it will be added and a
- *  notification will be sent.
+/** Check if there is a cron job scheduled to run.
+ *  If the scheduling job is found then all is good.
+ *  If the scheduling job is not found, it will be added
+ *  and a notification will be sent.
  */
 function install_cron_scheduler() {
 	global $amp_conf;
@@ -955,8 +957,9 @@ function install_cron_scheduler() {
 		} else {
 			$userArray = posix_getpwuid(posix_geteuid());
 			if ($userArray['name'] != $amp_conf['AMPASTERISKWEBUSER']) {
-				//we arent the user we need to be
-				//and we aren't root so nothing we can do
+				// we are not the user we need to be,
+				// and we aren't root, so there is nothing
+				// we can do but report the error condition
 				$nt->add_critical("FRAMEWORK", "CRON_UPDATE", _("Unable to create or update cron jobs"), sprintf(_("The PBX is running as %s but according to Advanced Settings it should be running as %. Therefore no cron jobs have been created. This can cause serious problems with your PBX in the future if it is not resolved"),$userArray['name'],$amp_conf['AMPASTERISKWEBUSER']));
 				return true;
 			} else {

--- a/amp_conf/bin/retrieve_conf
+++ b/amp_conf/bin/retrieve_conf
@@ -196,111 +196,115 @@ class connectdirs {
 		}
 	}
 
-  function do_symlink($src, $dest, $subdir, $moduledir) {
-	global $amp_conf;
-    if (file_exists_wrapper($dest)) {
-      if ((!is_link($dest) || readlink($dest) != $src) && file_exists($src) && file_exists($dest) && (md5_file($src) == md5_file($dest))) {
-        // dbug('retrieve-conf', "Can't symlink $src to $dest but files are the same so ignoring");
-      } else if (!is_link($dest)) {
-		//If the symlink error is coming from the etc directory then we move those files to backup
-		if(preg_match('/^'.str_replace("/","\/",$amp_conf['ASTETCDIR']).'/',$dest) && is_writable($dest)) {
-			if(!file_exists($amp_conf['ASTETCDIR'].'/backup')) {
-				mkdir($amp_conf['ASTETCDIR'].'/backup');
-			}
-			$f = $amp_conf['ASTETCDIR'].'/backup/'.basename($dest).".bk.".time();
-			rename($dest,$f);
-			if (!symlink($src, $dest)) {
-				freepbx_log(FPBX_LOG_ERROR, sprintf(_('Cannot symlink %s to %s. Check Permissions?'),$src,$dest));
-			} else {
-				$this->symlink_notice_modules .= "<br />&nbsp;&nbsp;&nbsp;".$dest;
+	function do_symlink($src, $dest, $subdir, $moduledir) {
+		global $amp_conf;
+		if (file_exists_wrapper($dest)) {
+			if ((!is_link($dest) || readlink($dest) != $src) && file_exists($src) && file_exists($dest) && (md5_file($src) == md5_file($dest))) {
+				// dbug('retrieve-conf', "Can't symlink $src to $dest but files are the same so ignoring");
+			} else if (!is_link($dest)) {
+				//If the symlink error is coming from the etc directory then we move those files to backup
+				if(preg_match('/^'.str_replace("/","\/",$amp_conf['ASTETCDIR']).'/',$dest) && is_writable($dest)) {
+					if(!file_exists($amp_conf['ASTETCDIR'].'/backup')) {
+						mkdir($amp_conf['ASTETCDIR'].'/backup');
+					}
+					$f = $amp_conf['ASTETCDIR'].'/backup/'.basename($dest).".bk.".time();
+					rename($dest,$f);
+					if (!symlink($src, $dest)) {
+						freepbx_log(FPBX_LOG_ERROR, sprintf(_('Cannot symlink %s to %s. Check Permissions?'),$src,$dest));
+					} else {
+						$this->symlink_notice_modules .= "<br />&nbsp;&nbsp;&nbsp;".$dest;
+					}
+				} else {
+					freepbx_log(FPBX_LOG_ERROR, sprintf(_('%s already exists, and is not a symlink!'),$dest));
+					$this->symlink_error_modules .= "<br />&nbsp;&nbsp;&nbsp;".sprintf(_("%s from %s/%s (Already exists, not a link)"),$dest,basename($moduledir),$subdir);
+				}
+			} else if (readlink($dest) != $src) {
+				//users need to be aware of symlink conflicts. We should attempt to resolve them properly though. So lets do that.
+				freepbx_log(FPBX_LOG_ERROR, $dest.' already exists, and is linked to something else!');
+				$this->symlink_error_modules .= "<br />&nbsp;&nbsp;&nbsp;".sprintf(_("%s from %s/%s (Already exists, linked to something else)"),$dest,basename($moduledir),$subdir);
 			}
 		} else {
-        	freepbx_log(FPBX_LOG_ERROR, sprintf(_('%s already exists, and is not a symlink!'),$dest));
-        	$this->symlink_error_modules .= "<br />&nbsp;&nbsp;&nbsp;".sprintf(_("%s from %s/%s (Already exists, not a link)"),$dest,basename($moduledir),$subdir);
+			$targetdir = dirname($dest);
+			if (!is_dir($targetdir)) {
+				freepbx_log(FPBX_LOG_ERROR, sprintf(_("Tried to link %s to %s, but %s doesn't exist"),$src,$dest,$targetdir));
+			} else {
+				if (!symlink($src, $dest)) {
+					freepbx_log(FPBX_LOG_ERROR, sprintf(_('Cannot symlink %s to %s. Check Permissions?'),$src,$dest));
+				}
+			}
 		}
-      } else if (readlink($dest) != $src) {
-		//users need to be aware of symlink conflicts. We should attempt to resolve them properly though. So lets do that.
-        freepbx_log(FPBX_LOG_ERROR, $dest.' already exists, and is linked to something else!');
-        $this->symlink_error_modules .= "<br />&nbsp;&nbsp;&nbsp;".sprintf(_("%s from %s/%s (Already exists, linked to something else)"),$dest,basename($moduledir),$subdir);
-      }
-    } else {
-      $targetdir = dirname($dest);
-      if (!is_dir($targetdir)) {
-        freepbx_log(FPBX_LOG_ERROR, sprintf(_("Tried to link %s to %s, but %s doesn't exist"),$src,$dest,$targetdir));
-      } else {
-        if (!symlink($src, $dest)) {
-          freepbx_log(FPBX_LOG_ERROR, sprintf(_('Cannot symlink %s to %s. Check Permissions?'),$src,$dest));
-        }
-      }
-    }
-  }
-
-  function symlink_check_errors() {
-	global $amp_conf;
-    if ($this->symlink_error_modules) {
-		$this->nt->add_error('retrieve_conf', 'SYMLINK', _("Symlink from modules failed"), sprintf(_("retrieve_conf failed to sym link: %s<br \>This can result in FATAL failures to your PBX. If the target file exists and not identical, the symlink will not occur and you should rename the target file to allow the automatic sym link to occur and remove this error, unless this is an intentional customization."),$this->symlink_error_modules));
-	} else {
-		$this->nt->delete('retrieve_conf', 'SYMLINK');
 	}
-	if($this->symlink_notice_modules) {
-		$this->nt->add_notice('retrieve_conf', 'SYMLINKNOTICE', _("Symlink Conflict Resolved"),sprintf(_("retrieve_conf resolved a symlink with %s<br \>This is a notice to let you know that the original file was moved to %s, there is nothing more you need to do"),$this->symlink_notice_modules,$amp_conf['ASTETCDIR'].'/backup'));
-	}
-  }
 
-  function cp_subdirs($moduledir) {
+	function symlink_check_errors() {
 		global $amp_conf;
-    foreach ($this->cp_dirs as $subdir => $targetdir) {
-		  $dir = addslash($moduledir).$subdir;
-		  if(is_dir($dir)){
-			  foreach(listdir($dir) as $idx => $file){
-				  $sourcefile = $file;
-				  $filesubdir=str_replace($dir.'/', '', $file);
-				  $targetfile = addslash($targetdir).$filesubdir;
+		if ($this->symlink_error_modules) {
+			$this->nt->add_error('retrieve_conf', 'SYMLINK', _("Symlink from modules failed"), sprintf(_("retrieve_conf failed to sym link: %s<br \>This can result in FATAL failures to your PBX. If the target file exists and not identical, the symlink will not occur and you should rename the target file to allow the automatic sym link to occur and remove this error, unless this is an intentional customization."),$this->symlink_error_modules));
+		} else {
+			$this->nt->delete('retrieve_conf', 'SYMLINK');
+		}
+		if($this->symlink_notice_modules) {
+			$this->nt->add_notice('retrieve_conf', 'SYMLINKNOTICE', _("Symlink Conflict Resolved"),sprintf(_("retrieve_conf resolved a symlink with %s<br \>This is a notice to let you know that the original file was moved to %s, there is nothing more you need to do"),$this->symlink_notice_modules,$amp_conf['ASTETCDIR'].'/backup'));
+		}
+	}
 
-				  if (file_exists_wrapper($targetfile)) {
-					  if (is_link($targetfile)) {
-              if (!$this->err_unlink($targetfile)) {
-							  freepbx_log(FPBX_LOG_ERROR, sprintf(_("%s is a symbolic link, failed to unlink!"),$targetfile));
-							  break;
-						  }
-					  }
-				  }
-				  // OK, now either the file is a regular file or isn't there, so proceed
-				  //
-          if ($this->err_copy($sourcefile,$targetfile)) {
-					  // copy was successful, make sure it has execute permissions
-					  chmod($targetfile,0755);
+	function cp_subdirs($moduledir) {
+		global $amp_conf;
+		foreach ($this->cp_dirs as $subdir => $targetdir) {
+			$dir = addslash($moduledir).$subdir;
+			if(is_dir($dir)){
+				foreach(listdir($dir) as $idx => $file){
+					$sourcefile = $file;
+					$filesubdir=str_replace($dir.'/', '', $file);
+					$targetfile = addslash($targetdir).$filesubdir;
+
+					if (file_exists_wrapper($targetfile)) {
+						if (is_link($targetfile)) {
+							if (!$this->err_unlink($targetfile)) {
+								freepbx_log(FPBX_LOG_ERROR, sprintf(_("%s is a symbolic link, failed to unlink!"),$targetfile));
+								break;
+							}
+						}
+					}
+					// OK, now either the file is a regular file or
+					// isn't there, so proceed
+					if ($this->err_copy($sourcefile,$targetfile)) {
+						// copy was successful, make sure it has execute permissions
+						chmod($targetfile,0755);
 						$ampowner = $amp_conf['AMPASTERISKWEBUSER'];
-						/* Address concerns carried over from amportal in FREEPBX-8268. If the apache user is different
-						 * than the Asterisk user we provide permissions that allow both.
+						/* Address concerns carried over from amportal
+						 * in FREEPBX-8268. If the apache user is different
+						 * than the Asterisk user we provide permissions
+						 * that allow both.
 						 */
 						$ampgroup =  $amp_conf['AMPASTERISKWEBUSER'] != $amp_conf['AMPASTERISKUSER'] ? $amp_conf['AMPASTERISKGROUP'] : $amp_conf['AMPASTERISKWEBGROUP'];
 						chown($targetfile, $ampowner);
 						chgrp($targetfile, $ampgroup);
-				  } else {
-					  freepbx_log(FPBX_LOG_ERROR, sprintf(_("%s failed to copy from module directory"),$targetfile));
-				  }
-			  }
-		  }
-	  }
-  }
-  function cp_check_errors() {
-    if ($this->cp_errors) {
-      $this->nt->add_error('retrieve_conf', 'CPAGIBIN', _("Failed to copy from module agi-bin"), sprintf(_("Retrieve conf failed to copy file(s) from a module's agi-bin dir: %s"),$this->cp_errors));
-	  } else {
-      $this->nt->delete('retrieve_conf', 'CPAGIBIN');
-	  }
-  }
-  function add_cp_error($string) {
-    $this->cp_errors .= $string;
-  }
+					} else {
+						freepbx_log(FPBX_LOG_ERROR, sprintf(_("%s failed to copy from module directory"),$targetfile));
+					}
+				}
+			}
+		}
+	}
 
-  // wrap copy with error handler
-  //
+	function cp_check_errors() {
+		if ($this->cp_errors) {
+			$this->nt->add_error('retrieve_conf', 'CPAGIBIN', _("Failed to copy from module agi-bin"), sprintf(_("Retrieve conf failed to copy file(s) from a module's agi-bin dir: %s"),$this->cp_errors));
+		} else {
+			$this->nt->delete('retrieve_conf', 'CPAGIBIN');
+		}
+	}
+
+	function add_cp_error($string) {
+		$this->cp_errors .= $string;
+	}
+
+	// wrap copy with error handler
+	//
 	function err_copy($source, $dest) {
 		$ret = false;
 		set_error_handler("report_errors");
-		  //if were copying a directory, just mkdir the directory
+		//if were copying a directory, just mkdir the directory
 		if (!is_link($dest) && !is_dir($dest)) {
 			if(is_dir($source)){
 				$ret = mkdir($dest,0754);
@@ -312,25 +316,24 @@ class connectdirs {
 		return $ret;
 	  }
 
-  // wrap unlink with error handler
-  //
-  function err_unlink($dest) {
-	  set_error_handler("report_errors");
-	  $ret = unlink($dest);
-	  restore_error_handler();
-	  return $ret;
-  }
+	// wrap unlink with error handler
+	function err_unlink($dest) {
+		set_error_handler("report_errors");
+		$ret = unlink($dest);
+		restore_error_handler();
+		return $ret;
+	}
 }
 
 // I don't think this can be part of the class since it is called by an
 // error function as a callback (otherwise, can move it into above).
 //
 function report_errors($errno, $errstr, $errfile, $errline) {
-  global $db;
-  $escaped_string = $db->escapeSimple($errstr);
+	global $db;
+	$escaped_string = $db->escapeSimple($errstr);
 	freepbx_log(FPBX_LOG_ERROR, sprintf(_("php reported: '%s' after copy or unlink attempt!"),$escaped_string));
-  $conn_dirs = connectdirs::create();
-  $conn_dirs->add_cp_error($errstr."\n");
+	$conn_dirs = connectdirs::create();
+	$conn_dirs->add_cp_error($errstr."\n");
 }
 
 //define("ASTERISK_CONF", "/etc/asterisk/asterisk.conf");
@@ -343,8 +346,7 @@ function showHelp() {
 	out("  --dry-run                "._("Don't actually do anything"),false);
 }
 
-/** Adds a trailing slash to a directory, if it doesn't already have one
- */
+// Adds a trailing slash to a directory, if it doesn't already have one
 function addslash($dir) {
 	return (($dir[ strlen($dir)-1 ] == '/') ? $dir : $dir.'/');
 }

--- a/amp_conf/htdocs/admin/libraries/BMO/GPG.class.php
+++ b/amp_conf/htdocs/admin/libraries/BMO/GPG.class.php
@@ -413,14 +413,16 @@ class GPG {
 		}
 
 		$webuser = \FreePBX::Freepbx_conf()->get('AMPASTERISKWEBUSER');
-		$home = $this->getGpgLocation();
+		$gpgdir = $this->getGpgLocation();
+		$homediropt = "--homedir $gpgdir";
+		$home = preg_replace('/\/\.gnupg$/', '', $gpgdir);
 
 		// We need to ensure that our environment variables are sane.
 		// Luckily, we know just the right things to say...
 		if (!isset($this->gpgenv)) {
 			$this->gpgenv['PATH'] = "/bin:/usr/bin:/usr/local/bin";
 			$this->gpgenv['USER'] = $webuser;
-			$this->gpgenv['HOME'] = sys_get_temp_dir();
+			$this->gpgenv['HOME'] = $home;
 			if (file_exists('/bin/bash')) {
 				$this->gpgenv['SHELL'] = "/bin/bash";
 			} elseif (file_exists('/usr/local/bin/bash')) {
@@ -430,9 +432,7 @@ class GPG {
 			}
 		}
 
-		$homedir = "--homedir $home";
-
-		$cmd = $this->gpg." $homedir ".$this->gpgopts." --status-fd 3 $params";
+		$cmd = $this->gpg." $homediropt ".$this->gpgopts." --status-fd 3 $params";
 		$proc = proc_open($cmd, $fds, $pipes, "/tmp", $this->gpgenv);
 
 		if (!is_resource($proc)) { // Unable to start!

--- a/amp_conf/htdocs/admin/libraries/BMO/GPG.class.php
+++ b/amp_conf/htdocs/admin/libraries/BMO/GPG.class.php
@@ -418,10 +418,16 @@ class GPG {
 		// We need to ensure that our environment variables are sane.
 		// Luckily, we know just the right things to say...
 		if (!isset($this->gpgenv)) {
-			$this->gpgenv['PATH'] = "/bin:/usr/bin";
+			$this->gpgenv['PATH'] = "/bin:/usr/bin:/usr/local/bin";
 			$this->gpgenv['USER'] = $webuser;
 			$this->gpgenv['HOME'] = sys_get_temp_dir();
-			$this->gpgenv['SHELL'] = "/bin/bash";
+			if (file_exists('/bin/bash')) {
+				$this->gpgenv['SHELL'] = "/bin/bash";
+			} elseif (file_exists('/usr/local/bin/bash')) {
+				$this->gpgenv['SHELL'] = "/usr/local/bin/bash";
+			} else {
+				$this->gpgenv['SHELL'] = "/bin/sh";
+			}
 		}
 
 		$homedir = "--homedir $home";

--- a/amp_conf/htdocs/admin/libraries/BMO/PKCS.class.php
+++ b/amp_conf/htdocs/admin/libraries/BMO/PKCS.class.php
@@ -385,10 +385,16 @@ default_md = sha256
 		// We need to ensure that our environment variables are sane.
 		// Luckily, we know just the right things to say...
 		if (!isset($this->opensslenv)) {
-			$this->opensslenv['PATH'] = "/bin:/usr/bin";
+			$this->opensslenv['PATH'] = "/bin:/usr/bin:/usr/local/bin";
 			$this->opensslenv['USER'] = $webuser;
 			$this->opensslenv['HOME'] = $keyloc;
-			$this->opensslenv['SHELL'] = "/bin/bash";
+			if (file_exists('/bin/bash')) {
+				$this->opensslenv['SHELL'] = "/bin/bash";
+			} elseif (file_exists('/usr/local/bin/bash')) {
+				$this->opensslenv['SHELL'] = "/usr/local/bin/bash";
+			} else {
+				$this->opensslenv['SHELL'] = "/bin/sh";
+			}
 		}
 
 		$cmd = $this->openssl. " $params";

--- a/amp_conf/htdocs/admin/libraries/modulefunctions.class.php
+++ b/amp_conf/htdocs/admin/libraries/modulefunctions.class.php
@@ -3034,21 +3034,19 @@ class module_functions {
 						$sth = FreePBX::Database()->prepare("SELECT value FROM admin WHERE variable = 'unsigned' LIMIT 1");
 						$sth->execute();
 						$o = $sth->fetch();
-						if(empty($o)) {
-							$nt->add_signature_unsigned('freepbx', 'FW_'.strtoupper($type), sprintf(_('You have %s unsigned modules'),count($modules['statuses'][$type])), implode("<br>",$modules['statuses'][$type]),'',true,true);
-							sql("INSERT INTO admin (variable, value) VALUE ('unsigned', '$hash')");
-						} elseif($o['value'] != $hash) {
-							$nt->add_signature_unsigned('freepbx', 'FW_'.strtoupper($type), sprintf(_('You have %s unsigned modules'),count($modules['statuses'][$type])), implode("<br>",$modules['statuses'][$type]),'',true,true);
-							$sth = FreePBX::Database()->prepare("UPDATE admin SET value = ? WHERE variable = 'unsigned'");
-							$sth->execute(array($hash));
+						if (empty($o) || ($o['value'] != $hash)) {
+							$nt->add_signature_unsigned('freepbx', 'FW_'.strtoupper($type), sprintf(_('You have %s %s modules'),count($modules['statuses'][$type]),$name), implode("\n",$modules['statuses'][$type]),'',true,true);
+							if (empty($o)) {
+								sql("INSERT INTO admin (variable, value) VALUE ('unsigned', '$hash')");
+							} else {
+								$sth = FreePBX::Database()->prepare("UPDATE admin SET value = ? WHERE variable = 'unsigned'");
+								$sth->execute(array($hash));
+							}
 						}
-					break;
-					case 'tampered':
-						$nt->add_security('freepbx', 'FW_'.strtoupper($type), sprintf(_('You have %s tampered files'),count($modules['statuses'][$type])), implode("<br>",$modules['statuses'][$type]));
-					break;
+						break;
 					default:
-						$nt->add_security('freepbx', 'FW_'.strtoupper($type), sprintf(_('You have %s %s modules'),count($modules['statuses'][$type]),$name), implode("<br>",$modules['statuses'][$type]));
-					break;
+						$nt->add_security('freepbx', 'FW_'.strtoupper($type), sprintf(_('You have %s %s modules'),count($modules['statuses'][$type]),$name), implode("\n",$modules['statuses'][$type]));
+						break;
 				}
 			} else {
 				$nt->delete('freepbx', 'FW_'.strtoupper($type));


### PR DESCRIPTION
There's a real bug on FreeBSD, where the environment that is
created before gpg and openssl are run have an invalid shell.
This one is important to fix.

The other change is a code refactoring of how the notifications
for unsigned/tampered modules are generated.  The git commit
message explains it.
