### PR TITLE
Locate installed ASTAGIDIR correctly

### DIFF
--- a/install.php
+++ b/install.php
@@ -19,7 +19,6 @@ function framework_print_errors($src, $dst, $errors) {
 }
 
 global $amp_conf;
-global $asterisk_conf;
 
 // default php will check local path, or should we add that in?
 //include "libfreepbx.install.php";
@@ -77,7 +76,7 @@ if (is_link("$wr/admin/images/notify_security.png")) {
 
 	$htdocs_dest = $amp_conf['AMPWEBROOT'];
 	$bin_dest    = isset($amp_conf['AMPBIN']) ? $amp_conf['AMPBIN'] : '/var/lib/asterisk/bin';
-	$agibin_dest = isset($asterisk_conf['astagidir']) ? $asterisk_conf['astagidir']:'/var/lib/asterisk/agi-bin';
+	$agibin_dest = isset($amp_conf['ASTAGIDIR']) ? $amp_conf['ASTAGIDIR']:'/var/lib/asterisk/agi-bin';
 
 	$msg = _("installing files to %s..");
 


### PR DESCRIPTION
The asterisk_conf array is not filled out, so the $agibin_dest was always being
set to /var/lib/asterisk/agi-bin when the installation script ran.

Use the value stored in the amp_conf database to figure out where to copy the
agi-bin scripts.
