### PR TITLE
Fix bug: SIGNATURE_CHECK setting ignored

### DIFF
--- a/amp_conf/bin/retrieve_conf
+++ b/amp_conf/bin/retrieve_conf
@@ -1094,14 +1094,15 @@ else
 	out(_("Please update your modules and reload Asterisk by browsing to your server."),false);
 }
 
-$bmo->Performance->Start("Signature Checks");
-module_functions::create()->getAllSignatures(false);
-$bmo->Performance->Stop();
-
 if(!FreePBX::Config()->get('SIGNATURECHECK')) {
 	$nt->add_notice('freepbx', 'SIGNATURE_CHECK', _('Signature checking is disabled'), _('FreePBX Module Signature checking has been disabled. Your system could be exposed to security vulnerabilities from compromised or tampered code'));
 } else {
 	$nt->delete('freepbx', 'SIGNATURE_CHECK');
+	
+	$bmo->Performance->Start("Signature Checks");
+	module_functions::create()->getAllSignatures(false);
+	$bmo->Performance->Stop();
+
 }
 
 $nt->delete('retrieve_conf', 'FATAL');


### PR DESCRIPTION
If SIGNATURE_CHECK is disabled, retrieve_conf still tries to refresh them. IMO SIGNATURE_CHECK = false should totally disable signature validation operations