### PR TITLE
Make getSystemMemInfo work on FreeBSD

### DIFF
--- a/amp_conf/htdocs/admin/libraries/utility.functions.php
+++ b/amp_conf/htdocs/admin/libraries/utility.functions.php
@@ -1423,12 +1423,17 @@ function varsub($string, $del = '$') {
 	return $string;
 }
 
-function getSystemMemInfo() {       
-	$data = explode("\n", file_get_contents("/proc/meminfo"));
+function getSystemMemInfo() {
 	$meminfo = array();
-	foreach ($data as $line) {
-		list($key, $val) = explode(":", $line);
-		$meminfo[$key] = trim($val);
+	if (PHP_OS == "FreeBSD") {
+		$bytes = shell_exec("sysctl -n hw.usermem 2>/dev/null");
+		$meminfo["MemTotal"] = $bytes / 1024 ;
+	} else {
+		$data = explode("\n", file_get_contents("/proc/meminfo"));
+		foreach ($data as $line) {
+			list($key, $val) = explode(":", $line);
+			$meminfo[$key] = trim($val);
+		}
 	}
 	return $meminfo;
 }


### PR DESCRIPTION
The addition of the getSystemMemInfo function into the 'framework' module causes
it to fail to run on FreeBSD systems.  This is a minimal patch to supply the
one data value that is used by the caller.
