### PR TITLE
framework cleanups for valid html5 generation

### DIFF
--- a/amp_conf/htdocs/admin/helpers/Table.php
+++ b/amp_conf/htdocs/admin/helpers/Table.php
@@ -495,7 +495,7 @@ class CI_Table {
 	function _default_template()
 	{
 		return  array (
-						'table_open'			=> '<table border="0" cellpadding="4" cellspacing="0">',
+						'table_open'			=> '<table style="border-style: none; border-spacing: 4px;">',
 
 						'thead_open'			=> '<thead>',
 						'thead_close'			=> '</thead>',

--- a/amp_conf/htdocs/admin/views/footer.php
+++ b/amp_conf/htdocs/admin/views/footer.php
@@ -16,7 +16,7 @@ if ($amp_conf['FORCE_JS_CSS_IMG_DOWNLOAD']) {
 
 $html = '';
 
-$html .= '</div></div>';//page_body
+$html .= '</div>';//page_body
 $html .= '<div id="footer">';
 // If displaying footer content, force the <hr /> tag to enforce clear separation of page vs. footer
 if ($footer_content) {

--- a/amp_conf/htdocs/admin/views/menu.php
+++ b/amp_conf/htdocs/admin/views/menu.php
@@ -7,7 +7,7 @@ global $_item_sort;
 		<div class="container-fluid">
 			<div class="navbar-header">
 				<button type="button" class="navbar-toggle navbar-left collapsed" data-toggle="collapse" data-target="#fpbx-menu-collapse">
-					<span class="sr-only"><php echo _("Toggle navigation")?></span>
+					<span class="sr-only"><?php echo _("Toggle navigation")?></span>
 					<span class="icon-bar"></span>
 					<span class="icon-bar"></span>
 					<span class="icon-bar"></span>


### PR DESCRIPTION
During html5 validation checks, came across some issues.  In addition to missing ? on echo, match div's from views/header.php to views/footer.php.  Header leaves one open div "page" but footer was attempting to close two divs at page_body prior to adding actual footer content.