### PR TITLE
Correctly process "rdir" and "execdir" sections of freepbx_chown.conf

### DIFF
--- a/amp_conf/htdocs/admin/libraries/Console/Chown.class.php
+++ b/amp_conf/htdocs/admin/libraries/Console/Chown.class.php
@@ -81,7 +81,7 @@ class Chown extends Command {
 						);
 				}
 			}
-			if(isset($conf['custom'][''])){
+			if(isset($conf['custom']['rdir'])){
 				$conf['custom']['rdir'] = is_array($conf['custom']['rdir'])?$conf['custom']['rdir']:array($conf['custom']['rdir']);
 				foreach (	$conf['custom']['rdir']  as $rdir) {
 					$rdir = $this->parse_conf_line($rdir);
@@ -95,7 +95,7 @@ class Chown extends Command {
 						);
 				}
 			}
-			if(isset($conf['custom'][''])){
+			if(isset($conf['custom']['execdir'])){
 				$conf['custom']['execdir'] = is_array($conf['custom']['execdir'])?$conf['custom']['execdir']:array($conf['custom']['execdir']);
 				foreach (	$conf['custom']['execdir']  as $edir) {
 					$edir = $this->parse_conf_line($rdir);

--- a/amp_conf/htdocs/admin/views/footer.php
+++ b/amp_conf/htdocs/admin/views/footer.php
@@ -319,7 +319,7 @@ addLoadEvent(function(){
     console.log("For developer resources visit: http://wiki.freepbx.org/x/BAAQ");
     ';
   }
-  if(!empty($module_name)){
+  if(!empty($module_name) && isset($active_modules[$module_name])){
   $consolealert .='
     console.log(("Framework: %s"),"'. $version .'");
     console.log(("Module Name: %s"),"'. $module_name .'");


### PR DESCRIPTION
Fixes FREEPBX-13253.

Also addresses unrelated "undefined index" notice.