### PR TITLE
allow foreign keys

### DIFF
--- a/amp_conf/htdocs/admin/libraries/BMO/Database/Migration.class.php
+++ b/amp_conf/htdocs/admin/libraries/BMO/Database/Migration.class.php
@@ -56,6 +56,9 @@ class Migration {
 					}
 					$table->addIndex($columns,$name,array("fulltext"));
 				break;
+				case "foreign":
+					$table->addForeignKeyConstraint($data['foreigntable'], $columns, $data['foreigncols'], $data['options'], $name);
+				break;
 			}
 		}
 


### PR DESCRIPTION
this works well for me in testing. `$data['foreigncols']` and `$data['cols']` are both arrays; `$data['options']` looks something like this:

    $options = ["onupdate"=>"CASCADE", "ondelete"=>"CASCADE"];