### PR TITLE
don't break on URL query strings

### DIFF
--- a/amp_conf/htdocs/admin/libraries/modulefunctions.class.php
+++ b/amp_conf/htdocs/admin/libraries/modulefunctions.class.php
@@ -1618,7 +1618,7 @@ class module_functions {
 			$progress_callback[0]->$progress_callback[1]('getinfo', array('module'=>$modulename));
 		}
 
-		$file = basename($module_location);
+		$file = basename(parse_url($module_location, PHP_URL_PATH));
 		$filename = $amp_conf['AMPWEBROOT']."/admin/modules/_cache/".$file;
 
 		// Check each URL until get_headers_assoc() returns something intelligible. We then use


### PR DESCRIPTION
Running `fwconsole ma downloadinstall http://example.com/foo.tgz?version=123` doesn't work because it's looking at `.tgz?version=123` as the filename suffix. This patch parses the URL properly, removing the query string.