### PR TITLE
Allow third party modules to specify a remote update URL

### DIFF
--- a/amp_conf/htdocs/admin/libraries/modulefunctions.class.php
+++ b/amp_conf/htdocs/admin/libraries/modulefunctions.class.php
@@ -1406,7 +1406,7 @@ class module_functions {
 		} else {
 			if (parse_url($modulexml["location"], PHP_URL_SCHEME) === 'https') {
 				// absolute https URL was provided
-				$url_list = [$modulexml['location']];
+				$url_list = array($modulexml['location']);
 			} else {
 				$urls = $this->generate_remote_urls("/modules/".$modulexml['location'], true);
 				foreach($urls['mirrors'] as $url) {

--- a/amp_conf/htdocs/admin/libraries/modulefunctions.class.php
+++ b/amp_conf/htdocs/admin/libraries/modulefunctions.class.php
@@ -1404,9 +1404,14 @@ class module_functions {
 		if ($override_svn) {
 			$url_list = array($override_svn.$modulexml['location']);
 		} else {
-			$urls = $this->generate_remote_urls("/modules/".$modulexml['location'], true);
-			foreach($urls['mirrors'] as $url) {
-				$url_list[] = $url.$urls['path'];
+			if (parse_url($modulexml["location"], PHP_URL_SCHEME) === 'https') {
+				// absolute https URL was provided
+				$url_list = [$modulexml['location']];
+			} else {
+				$urls = $this->generate_remote_urls("/modules/".$modulexml['location'], true);
+				foreach($urls['mirrors'] as $url) {
+					$url_list[] = $url.$urls['path'];
+				}
 			}
 		}
 

--- a/amp_conf/htdocs/admin/page.modules.php
+++ b/amp_conf/htdocs/admin/page.modules.php
@@ -129,6 +129,20 @@ if ($online) {
 		$online = 0;
 		unset($modules_online);
 	} else {
+		// check for local-only modules and see if they have online update data
+		foreach(array_diff(array_keys($modules_local), array_keys($modules_online)) as $name) {
+			if ($name === "builtin") continue;
+			if (!empty($modules_local[$name]['updateurl']) && parse_url($modules_local[$name]['updateurl'], PHP_URL_SCHEME) === 'https') {
+				$module_update_json = file_get_contents($modules_local[$name]['updateurl']);
+				if ($module_update_json) {
+					$module_update_data = json_decode($module_update_json, true);
+					if ($module_update_data) {
+						$modules_online[$name] = $module_update_data;
+					}
+				}
+			}
+		}
+
 		// combine online and local modules
 		$modules = $modules_online;
 		foreach (array_keys($modules) as $name) {

--- a/amp_conf/htdocs/admin/page.modules.php
+++ b/amp_conf/htdocs/admin/page.modules.php
@@ -131,14 +131,13 @@ if ($online) {
 	} else {
 		// check for local-only modules and see if they have online update data
 		foreach(array_diff(array_keys($modules_local), array_keys($modules_online)) as $name) {
-			if ($name === "builtin") continue;
-			if (!empty($modules_local[$name]['updateurl']) && parse_url($modules_local[$name]['updateurl'], PHP_URL_SCHEME) === 'https') {
-				$module_update_json = file_get_contents($modules_local[$name]['updateurl']);
-				if ($module_update_json) {
-					$module_update_data = json_decode($module_update_json, true);
-					if ($module_update_data) {
-						$modules_online[$name] = $module_update_data;
-					}
+			if ($name === "builtin" || empty($modules_local[$name]['updateurl'])) {
+				continue;
+			}
+			if (parse_url($modules_local[$name]['updateurl'], PHP_URL_SCHEME) === 'https') {
+				$module_update_json = $modulef->url_get_contents($modules_local[$name]['updateurl'], "");
+				if ($module_update_json && $module_update_data = json_decode($module_update_json, true)) {
+					$modules_online[$name] = $module_update_data;
 				}
 			}
 		}


### PR DESCRIPTION
Re [FREEPBX-14064](http://issues.freepbx.org/browse/FREEPBX-14064)

This was easier than I expected, but it seems to work. Tested updates successfully, and confirmed that version dependencies are handled the same way as standard modules.

Within `module.xml`, an `<updateurl>` element contains a link to a JSON file that looks like this:

```json
{
    "rawname": "module",
    "repo": "local",
    "name": "Module",
    "version": "2.3",
    "publisher": "Publisher",
    "license": "GPLv3+",
    "licenselink": "http://www.gnu.org/licenses/gpl-3.0.txt",
    "changelog": "Some changes",
    "category": "Admin",
    "description": "A module",
    "depends": {
        "version": "13.0",
        "phpversion": "5.6"
    },
    "supported": {
        "version": "13.0"
    },
    "location": "https://download.example.com/modules/module-2.3.tgz",
    "md5sum": "55278ae5d4ab4aa7a7047076d07305b2",
    "packaged": "1486679131"
}

```

(The code as is requires an HTTPS link to be used for both the update JSON and the module itself. In these days of letsencrypt.org someone hosting their own server has no excuse not to run HTTPS, but do change it if you see fit.)
