### PR TITLE
Add /usr/local/bin/gpg2 as a valid gpg binary

### DIFF
--- a/amp_conf/htdocs/admin/libraries/BMO/GPG.class.php
+++ b/amp_conf/htdocs/admin/libraries/BMO/GPG.class.php
@@ -64,7 +64,7 @@ class GPG {
 	public function __construct() {
 		// Make sure that the system location is checked first. It's possible
 		// that anything in /usr/local/bin could be malicious.
-		$locations = array("/usr/bin/gpg", "/usr/bin/gpg2", "/usr/local/bin/gpg");
+		$locations = array("/usr/bin/gpg", "/usr/bin/gpg2", "/usr/local/bin/gpg", "/usr/local/bin/gpg2");
 
 		// Loop through our GPG locations, and make sure they exist,
 		// and they're a file.
@@ -77,7 +77,7 @@ class GPG {
 		}
 
 		if (!$this->gpg) {
-			throw new Exception(_("Could not find gpg command!"));
+			throw new \Exception(_("Could not find gpg command!"));
 		}
 
 		$this->keydir = __DIR__."/signatures";


### PR DESCRIPTION
Add missing backslash before Exception handler when
no valid gpg binary is found.