### PR TITLE
Ensure namespacing is case-insensitive

### DIFF
--- a/amp_conf/htdocs/admin/libraries/BMO/DialplanHooks.class.php
+++ b/amp_conf/htdocs/admin/libraries/BMO/DialplanHooks.class.php
@@ -97,7 +97,7 @@ class DialplanHooks {
 					} elseif (isset($cmd['Class'])) {
 						// This is a new BMO Object!
 						$class = $cmd['Class'];
-						$rawname = strtolower(str_replace("FreePBX\\modules\\","",$class));
+						$rawname = strtolower(str_ireplace("FreePBX\\modules\\","",$class));
 						$name = ucfirst($rawname);
 						if (!method_exists($this->FreePBX->$name, "doDialplanHook")) {
 							out(sprintf(_("HANDLED-ERROR: %s->doDialplanHook() isn't there, but the module is saying it wants to hook. This is a bug in %s"), $class, $class));

--- a/amp_conf/htdocs/admin/libraries/BMO/FileHooks.class.php
+++ b/amp_conf/htdocs/admin/libraries/BMO/FileHooks.class.php
@@ -81,7 +81,7 @@ class FileHooks {
 		$hooks = $this->FreePBX->Hooks->getAllHooks();
 		if(is_array($hooks['ConfigFiles'])) {
 			foreach ($hooks['ConfigFiles'] as $hook) {
-				$mod = str_replace("FreePBX\\modules\\","",$hook);
+				$mod = str_ireplace("FreePBX\\modules\\","",$hook);
 				\modgettext::push_textdomain(strtolower($mod));
 				$hparts = explode("\\",$hook);
 				if(count($hparts) > 0) {

--- a/amp_conf/htdocs/admin/libraries/BMO/GuiHooks.class.php
+++ b/amp_conf/htdocs/admin/libraries/BMO/GuiHooks.class.php
@@ -283,7 +283,7 @@ class GuiHooks {
 	}
 
 	private function doBMOConfigPage($class, $display) {
-		$mod = str_replace("FreePBX\\modules\\","",$class);
+		$mod = str_ireplace("FreePBX\\modules\\","",$class);
 		if (method_exists($this->FreePBX->$class, "doConfigPageInit")) {
 			$this->FreePBX->Performance->Stamp($class."->doConfigPageInit-$display"."_start");
 			\modgettext::push_textdomain(strtolower($mod));

--- a/amp_conf/htdocs/admin/libraries/BMO/Hooks.class.php
+++ b/amp_conf/htdocs/admin/libraries/BMO/Hooks.class.php
@@ -49,7 +49,7 @@ class Hooks extends DB_Helper {
 
 		$allhooks = array();
 		foreach ($bmomodules as $mod) {
-			$rawname = strtolower(str_replace("FreePBX\\modules\\","",$mod));
+			$rawname = strtolower(str_ireplace("FreePBX\\modules\\","",$mod));
 			$name = ucfirst($rawname);
 			if(!in_array($rawname,$am)) {
 				continue;

--- a/amp_conf/htdocs/admin/libraries/BMO/Self_Helper.class.php
+++ b/amp_conf/htdocs/admin/libraries/BMO/Self_Helper.class.php
@@ -139,7 +139,7 @@ class Self_Helper extends DB_Helper {
 	 * @return bool True if found or throws exception
 	 */
 	private function loadObject($objname, $hint = null) {
-		$objname = str_replace('FreePBX\\modules\\','',$objname);
+		$objname = str_ireplace('FreePBX\\modules\\','',$objname);
 		$class = class_exists($this->moduleNamespace.$objname,false) ? $this->moduleNamespace.$objname : (class_exists($this->freepbxNamespace.$objname,false) ? $this->freepbxNamespace.$objname : $objname);
 
 		// If it already exists, we're fine.


### PR DESCRIPTION
PHP namespaces are case-insensitive, this patch ensures that framework code treats them as such. In the event you declare `namespace FreePBX\Modules` or `namespace FreePbx\modules` your module will not function properly. (This manifested for my module as `myGuiHooks()` and `myConfigPageInits()` not being seen.)