### PR TITLE
cosmetic fixes for rightnav

### DIFF
--- a/amp_conf/htdocs/admin/assets/less/freepbx/page.less
+++ b/amp_conf/htdocs/admin/assets/less/freepbx/page.less
@@ -652,7 +652,7 @@ div.attention {
 		.btn-block {
 			width: 98%; //http://issues.freepbx.org/browse/FREEPBX-12478
 		}
-		tr {
+		tbody tr {
 			cursor: pointer;
 		}
 	}

--- a/amp_conf/htdocs/admin/assets/less/freepbx/page.less
+++ b/amp_conf/htdocs/admin/assets/less/freepbx/page.less
@@ -676,14 +676,14 @@ div.attention {
 	.fixed-table-container {
 		margin-bottom: 10px;
 	}
-}
-#floating-nav-bar.locked {
-	position: absolute;
-	bottom: 165px;
-	top: inherit;
-}
-#floating-nav-bar.show {
-	right: 0;
+	&.locked {
+		position: absolute;
+		bottom: 165px;
+		top: inherit;
+	}
+	&.show {
+		right: 0;
+	}
 }
 
 

--- a/amp_conf/htdocs/admin/assets/less/freepbx/page.less
+++ b/amp_conf/htdocs/admin/assets/less/freepbx/page.less
@@ -112,9 +112,9 @@ input[type="search"]:focus,
 input[type="tel"]:focus,
 input[type="color"]:focus,
 .uneditable-input:focus {
-  border-color: @border-color;
-  box-shadow: 0 1px 1px rgba(0,0,0,.075) inset, 0 0 8px fadeout(darken(@background-color, 50%),40%);
-  outline: 0 none;
+	border-color: @border-color;
+	box-shadow: 0 1px 1px rgba(0,0,0,.075) inset, 0 0 8px fadeout(darken(@background-color, 50%),40%);
+	outline: 0 none;
 }
 
 a {
@@ -631,17 +631,17 @@ div.attention {
 
 #floating-nav-bar {
 	font-size: 14px;
-  transition: right .5s linear;
+	transition: right .5s linear;
 	right: -33.9%;
 	width: 33%;
 	position: fixed;
-  margin-top: 8px;
-  background-color: white;
-  top: 117px;
-  z-index: 500;
+	margin-top: 8px;
+	background-color: white;
+	top: 117px;
+	z-index: 500;
 	border-bottom-left-radius: 7px;
-  .box-shadow(-3px 3px 10px -2px darken(@background-color, 50%));
-  border: 1px solid @border-color;
+	.box-shadow(-3px 3px 10px -2px darken(@background-color, 50%));
+	border: 1px solid @border-color;
 	max-height: 274px;
 	border-right: none;
 	min-height: 104px;

--- a/amp_conf/htdocs/admin/assets/less/freepbx/page.less
+++ b/amp_conf/htdocs/admin/assets/less/freepbx/page.less
@@ -652,6 +652,9 @@ div.attention {
 		.btn-block {
 			width: 98%; //http://issues.freepbx.org/browse/FREEPBX-12478
 		}
+		tr {
+			cursor: pointer;
+		}
 	}
 	#fixed-list-button{
 		position: absolute;
@@ -669,6 +672,9 @@ div.attention {
 		outline: 0;
 		border-right: none;
 		font-size: 20px;
+	}
+	.fixed-table-container {
+		margin-bottom: 10px;
 	}
 }
 #floating-nav-bar.locked {


### PR DESCRIPTION
Increases spacing at bottom of table, and also displays a pointer over the table rows (I couldn't think of any modules where they aren't clickable.)

Before:
![screenshot 2017-04-28 11 10 44](https://cloud.githubusercontent.com/assets/1329102/25542978/9f38f988-2c09-11e7-91ff-90075d2971a3.png)

After:
![screenshot 2017-04-28 11 13 34](https://cloud.githubusercontent.com/assets/1329102/25542981/a4701e86-2c09-11e7-9a95-d41eb7086c42.png)
