### PR TITLE
Fix for fcrontab

### DIFF
--- a/amp_conf/htdocs/admin/libraries/BMO/Cron.class.php
+++ b/amp_conf/htdocs/admin/libraries/BMO/Cron.class.php
@@ -69,7 +69,7 @@ class Cron {
 	 * @return array Crontab lines for user
 	 */
 	public function getAll() {
-		exec('/usr/bin/crontab '.$this->uoption.' -l 2>&1', $output, $ret);
+		exec('/usr/bin/crontab '.$this->uoption.' -l 2>/dev/null', $output, $ret);
 		// Linux output
 		if (preg_match('/^no crontab for/', $output[0]))
 			return array();


### PR DESCRIPTION
By default in fcrontab shows the first line the INFO, example:

2017-06-29 13:44:41  INFO listing root's fcrontab



If you don't send 2> to null , It's include in next update and it has thousands of INFO lines

------------------------------
2017-06-28 03:10:00  INFO listing asterisk's fcrontab
2017-06-28 03:10:00  INFO listing asterisk's fcrontab
2017-06-28 03:09:00  INFO listing asterisk's fcrontab
2017-06-28 03:09:00  INFO listing asterisk's fcrontab
2017-06-28 03:08:00  INFO listing asterisk's fcrontab
2017-06-28 03:08:00  INFO listing asterisk's fcrontab
2017-06-28 03:07:00  INFO listing asterisk's fcrontab
2017-06-28 03:07:00  INFO listing asterisk's fcrontab
2017-06-28 03:06:00  INFO listing asterisk's fcrontab
2017-06-28 03:06:00  INFO listing asterisk's fcrontab
2017-06-28 03:05:01  INFO listing asterisk's fcrontab
2017-06-28 03:05:00  INFO listing asterisk's fcrontab
2017-06-28 03:04:00  INFO listing asterisk's fcrontab
2017-06-28 03:04:00  INFO listing asterisk's fcrontab
2017-06-28 03:03:00  INFO listing asterisk's fcrontab
2017-06-28 03:03:00  INFO listing asterisk's fcrontab
2017-06-28 03:02:00  INFO listing asterisk's fcrontab
2017-06-28 03:02:00  INFO listing asterisk's fcrontab
.
.
.

-------------
