### PR TITLE
Don't strip executable on individual files

### DIFF
--- a/amp_conf/htdocs/admin/libraries/Console/Chown.class.php
+++ b/amp_conf/htdocs/admin/libraries/Console/Chown.class.php
@@ -218,7 +218,7 @@ class Chown extends Command {
 					case 'dir':
 						try {
 							$this->checkPermissions($file['path'], $file['perms']);
-							$this->chmod($progress, $file['path'], $file['perms']);
+							$this->chmod($progress, $file['path'], $file['perms'], 0000, false, false);
 							$this->chown($progress, $file['path'], $owner);
 							$this->chgrp($progress, $file['path'], $group);
 						} catch(\Exception $e) {


### PR DESCRIPTION
Obviously if it's been specified on a single file, it's been done for a reason! Fixes FREEPBX-14185