### PR TITLE
blur the text only, not the entire element

### DIFF
--- a/amp_conf/htdocs/admin/assets/less/freepbx/page.less
+++ b/amp_conf/htdocs/admin/assets/less/freepbx/page.less
@@ -763,7 +763,8 @@ div.attention {
 }
 
 .confidential:not(:focus):not(:hover) {
-	filter: blur(3px)
+	color: transparent;
+	text-shadow: 0 0 5px rgba(0,0,0,0.5);
 }
 
 .btn-group>.btn:first-child:not(:last-child):not(.dropdown-toggle) {


### PR DESCRIPTION
This ensures the input's borders are not blurred, just the text.

I will be pushing out another PR on core that would resolve [FREEPBX-15896](https://issues.freepbx.org/browse/FREEPBX-15896) as discussed.