### PR TITLE
 Be more friendly with other distros

### DIFF
--- a/amp_conf/htdocs/admin/libraries/Builtin/SystemUpdates.php
+++ b/amp_conf/htdocs/admin/libraries/Builtin/SystemUpdates.php
@@ -431,6 +431,49 @@ class SystemUpdates {
 		return trim($vers[0]);
 	}
 
+         /**
+         * Get the Distro Name and Distro Version from /etc/os-release
+         *
+         * @return string to be displayed
+         */
+        public function getOSReleaseVersion() {
+
+                $osReleaseFile = "/etc/os-release";
+
+                if (file_exists($osReleaseFile)) {
+                        $osRelease = parse_ini_file($osReleaseFile);
+
+                        if ($osRelease['PRETTY_NAME']) {
+                                $distro = $osRelease['PRETTY_NAME'];
+                        }
+
+                        else {
+                                if ($osRelease['NAME']) {
+                                        $distro = $osRelease['NAME'];
+                                }
+                                else if ($osRelease['ID']) {
+                                        $distro = $osRelease['ID'];
+                                }
+                                else {
+                                        return "Unknown";
+                                }
+                                if ($osRelease['VERSION']) {
+                                        $distro .= ' ' . $osRelease['VERSION'];
+                                }
+                                else if ($osRelease['VERSION_ID']) {
+                                        $distro .= ' ' . $osRelease['VERSION_ID'];
+                                }
+                        }
+
+                        if ($distro) {
+                                //Strip special chars. Too paranoid?
+                                return preg_replace('/[^A-Za-z0-9\-_ \.\\/()]/', '', $distro);
+                        }
+                }
+
+                return "Unknown";
+        }
+
 	/**
 	 * Get the status of yum update
 	 */

--- a/amp_conf/htdocs/admin/page.modules.php
+++ b/amp_conf/htdocs/admin/page.modules.php
@@ -1024,10 +1024,10 @@ default:
 		"pbxversion" => $su->getDistroVersion(),
 	);
 
-        // Display version info for other distros.
-        if ($summary['pbxversion'] == 'Unknown') {
-                $summary['pbxversion'] = 'Asterisk ' . engine_getinfo()['version'] . ' - ' . $su->getOSReleaseVersion();
-        }
+	// Display version info for other distros.
+	if ($summary['pbxversion'] == 'Unknown') {
+        	$summary['pbxversion'] = 'Asterisk ' . engine_getinfo()['version'] . ' - ' . $su->getOSReleaseVersion();
+	}
 
 	// If we're not compatible with SU, don't try to do anything.
 	if (!$su->canDoSystemUpdates()) {

--- a/amp_conf/htdocs/admin/page.modules.php
+++ b/amp_conf/htdocs/admin/page.modules.php
@@ -1024,6 +1024,11 @@ default:
 		"pbxversion" => $su->getDistroVersion(),
 	);
 
+        // Display version info for other distros.
+        if ($summary['pbxversion'] == 'Unknown') {
+                $summary['pbxversion'] = 'Asterisk ' . engine_getinfo()['version'] . ' - ' . $su->getOSReleaseVersion();
+        }
+
 	// If we're not compatible with SU, don't try to do anything.
 	if (!$su->canDoSystemUpdates()) {
 		$summary['candosystemupdates'] = false;


### PR DESCRIPTION
For Non-FreePBX Distros: Instead of displaying "System Version: Unknown", Display Asterisk version and Distro version.