### PR TITLE
Resolve undefined variable warning

### DIFF
--- a/amp_conf/htdocs/admin/libraries/Console/Moduleadmin.class.php
+++ b/amp_conf/htdocs/admin/libraries/Console/Moduleadmin.class.php
@@ -1155,7 +1155,7 @@ class Moduleadmin extends Command {
 					fatal(_("Can not run this command while 'Developer Mode' is enabled"));
 				}
 				$this->check_active_repos();
-				$modules = $this->doUpgradeAll($force);
+				$modules = $this->doUpgradeAll($this->force);
 				$this->updateHooks();
 				foreach($modules as $module) {
 					$this->setPerms($action,array($module));


### PR DESCRIPTION
Seems like the use of the "force" option is quite messed up here. Lots of functions in this class take a `$force` argument but then ignore it in favour of the class property `$this->force`