### PR TITLE
Resolve undefined index notice

### DIFF
--- a/amp_conf/htdocs/admin/libraries/usage_registry.functions.php
+++ b/amp_conf/htdocs/admin/libraries/usage_registry.functions.php
@@ -352,7 +352,7 @@ function framework_list_problem_destinations($module_hash=false, $ignore_custom=
 
 	foreach ($all_dests as $dests) {
 		foreach ($dests as $adest) {
-			if (empty($adest['dest']) && !$adest['allow_empty']) {
+			if (empty($adest['dest']) && empty($adest['allow_empty'])) {
 				$problem_dests[] = array('status' => 'EMPTY',
 					                       'dest' => $adest['dest'],
 					                       'description' => $adest['description'],

--- a/amp_conf/htdocs/admin/libraries/usage_registry.functions.php
+++ b/amp_conf/htdocs/admin/libraries/usage_registry.functions.php
@@ -358,7 +358,7 @@ function framework_list_problem_destinations($module_hash=false, $ignore_custom=
 					                       'description' => $adest['description'],
 					                       'edit_url' => $adest['edit_url'],
 															  );
-			} else if ($identities[$adest['dest']] === false){
+			} else if (!empty($adest['dest']) && $identities[$adest['dest']] === false){
 				if ($ignore_custom) {
 					continue;
 				}
@@ -367,7 +367,7 @@ function framework_list_problem_destinations($module_hash=false, $ignore_custom=
 					                       'description' => $adest['description'],
 					                       'edit_url' => $adest['edit_url'],
 															  );
-			} else if (is_array($identities[$adest['dest']])){
+			} else if (!empty($adest['dest']) && is_array($identities[$adest['dest']])){
 				foreach ($identities[$adest['dest']] as $details) {
 					if (empty($details)) {
 						$problem_dests[] = array('status' => 'ORPHAN',


### PR DESCRIPTION
`empty()` will also check for false but won't trigger a notice. Needs to be backported to 13.0 as well.