### PR TITLE
Use env to find PHP interpreter

### DIFF
--- a/upgrades/1.10.007beta1/fixcallfw
+++ b/upgrades/1.10.007beta1/fixcallfw
@@ -1,4 +1,4 @@
-#!/usr/bin/php
+#!/usr/bin/env php
 <?php
 /**
 


### PR DESCRIPTION
Make the script more portable by using `env` to find the PHP interpreter. Fixes part of the installation process for FreePBX on FreeBSD.