### PR TITLE
Remove references to non-existing badge.png asset

### DIFF
--- a/amp_conf/htdocs/admin/views/header.php
+++ b/amp_conf/htdocs/admin/views/header.php
@@ -91,9 +91,7 @@ if(isset($module_name) && !empty($module_name)) {
 $html .= '<script type="text/javascript" src="assets/js/FreePBX.js' . $version_tag . '"></script>';
 
 $html .= '<meta name="viewport" content="width=device-width,user-scalable=no,initial-scale=1,maximum-scale=1">
-<meta name="apple-mobile-web-app-capable" content="yes" />
-<link rel="apple-touch-icon" href="assets/images/badge.png" />
-<link rel="apple-touch-icon-precomposed" href="assets/images/badge.png" />';
+<meta name="apple-mobile-web-app-capable" content="yes" />';
 
 $html .= '</head>';
 


### PR DESCRIPTION
There is no badge.png asset, resulting in 404s when clients try to request it. It's better not to include it, so that favicon.ico is used instead.