### PR TITLE
Make FreePBX\Database::query() compatible with PDO::query()

### DIFF
--- a/amp_conf/htdocs/admin/libraries/BMO/Database.class.php
+++ b/amp_conf/htdocs/admin/libraries/BMO/Database.class.php
@@ -237,7 +237,7 @@ class Database extends \PDO {
 		return $migrate->modifyMultiple($tables,$dryrun);
 	}
 
-	public function query(string $query, ?int $fetchMode = null, ...$fetchModeArgs) {
+	public function query(string $query = '', ?int $fetchMode = null, ...$fetchModeArgs) {
 		$args = func_get_args();
 		if(defined('LOGPREPARES')) {
 			$logger = \FreePBX::Logger()->createLogDriver('query_performance', \FreePBX::Config()->get('ASTLOGDIR').'/query_performance.log', \Monolog\Logger::DEBUG);

--- a/amp_conf/htdocs/admin/libraries/BMO/Database.class.php
+++ b/amp_conf/htdocs/admin/libraries/BMO/Database.class.php
@@ -237,7 +237,7 @@ class Database extends \PDO {
 		return $migrate->modifyMultiple($tables,$dryrun);
 	}
 
-	public function query() {
+	public function query(string $query, ?int $fetchMode = null, ...$fetchModeArgs) {
 		$args = func_get_args();
 		if(defined('LOGPREPARES')) {
 			$logger = \FreePBX::Logger()->createLogDriver('query_performance', \FreePBX::Config()->get('ASTLOGDIR').'/query_performance.log', \Monolog\Logger::DEBUG);


### PR DESCRIPTION
Resolves a fatal error and allows for upgrades to 17 using PHP 8