### PR TITLE
Fix notices when using sockets for database

### DIFF
--- a/amp_conf/htdocs/admin/libraries/BMO/Database.class.php
+++ b/amp_conf/htdocs/admin/libraries/BMO/Database.class.php
@@ -111,14 +111,7 @@ class Database extends \PDO {
 		}
 
 		// Always utf8.
-		$charset = "utf8";
-		if ($engine == 'mysql') {
-			//we cant learn the server version BEFORE we connect. So we have to figure it out now
-			$output = exec('mysql --version 2>/dev/null');
-			if(preg_match('/Distrib\s*(\d+\.\d+\.\d+)/i',$output,$matches) && version_compare($matches[1],"5.5.3","ge")) {
-				$charset = 'utf8mb4';
-			}
-		}
+		$charset = $engine === 'mysql' ? 'utf8mb4' : 'utf8';
 
 		$dsnarr['charset'] = $dsnarr['charset'] ?? $charset;
 

--- a/amp_conf/htdocs/admin/libraries/BMO/Database.class.php
+++ b/amp_conf/htdocs/admin/libraries/BMO/Database.class.php
@@ -74,11 +74,11 @@ class Database extends \PDO {
 
 		// Now go through and put anything in place that was missing
 		if (!isset($dsnarr['host'])) {
-			$dsnarr['host'] = isset($amp_conf['AMPDBHOST'])?$amp_conf['AMPDBHOST']:'localhost';
+			$dsnarr['host'] = $amp_conf['AMPDBHOST'] ?? 'localhost';
 		}
 
 		if (!isset($dsnarr['dbname'])) {
-			$dsnarr['dbname'] = isset($amp_conf['AMPDBNAME'])?$amp_conf['AMPDBNAME']:'asterisk';
+			$dsnarr['dbname'] = $amp_conf['AMPDBNAME'] ?? 'asterisk';
 		}
 
 		// Note the inverse logic. We REMOVE engine from dsnarr if it exists, because that
@@ -87,7 +87,7 @@ class Database extends \PDO {
 			$engine = $dsnarr['engine'];
 			unset ($dsnarr['engine']);
 		} else {
-			$engine = isset($amp_conf['AMPDBENGINE'])?$amp_conf['AMPDBENGINE']:'mysql';
+			$engine = $amp_conf['AMPDBENGINE'] ?? 'mysql';
 		}
 
 		$engine = ($engine == 'mariadb') ? 'mysql' : $engine;
@@ -120,10 +120,10 @@ class Database extends \PDO {
 			}
 		}
 
-		$dsnarr['charset'] = isset($dsnarr['charset']) ? $dsnarr['charset'] : $charset;
+		$dsnarr['charset'] = $dsnarr['charset'] ?? $charset;
 
 		// Were there any database options?
-		$options = isset($args[3]) ? $args[3] : array();
+		$options = $args[3] ?? [];
 		$dsnarr['driverOptions'] = $options;
 
 		//this id only for PDO
@@ -191,9 +191,9 @@ class Database extends \PDO {
 		global $amp_conf;
 		$host = $amp_conf['AMPDBHOST'];
 		$port = isset($amp_conf['AMPDBPORT'])?$amp_conf['AMPDBPORT']:'';
-		$dbuser = $this->FreePBX->Config->get('AMPDBUSER') ? $this->FreePBX->Config->get('AMPDBUSER'):$amp_conf['AMPDBUSER'];
-		$dbpass = $this->FreePBX->Config->get('AMPDBPASS') ? $this->FreePBX->Config->get('AMPDBPASS'):$amp_conf['AMPDBPASS'];
-		$dbname = $this->FreePBX->Config->get('AMPDBNAME') ? $this->FreePBX->Config->get('AMPDBNAME') : 'asterisk';
+		$dbuser = $this->FreePBX->Config->get('AMPDBUSER') ?: $amp_conf['AMPDBUSER'];
+		$dbpass = $this->FreePBX->Config->get('AMPDBPASS') ?: $amp_conf['AMPDBPASS'];
+		$dbname = $this->FreePBX->Config->get('AMPDBNAME') ?: 'asterisk';
 
 		if ($host =='localhost' || $host == '127.0.0.1') {
 			$hostname = '';

--- a/amp_conf/htdocs/admin/libraries/BMO/Database.class.php
+++ b/amp_conf/htdocs/admin/libraries/BMO/Database.class.php
@@ -298,11 +298,15 @@ class Database extends \PDO {
 				'dbname' => $this->dsnarr['dbname'],
 				'user' => $this->username,
 				'password' => $this->password,
-				'host' => $this->dsnarr['host'],
 				'driver' => self::$driverSchemeAliases[$this->engine],
-				'port' => $this->dsnarr['port'],
 				'charset' => $this->dsnarr['charset'],
 			];
+			$optional = ['host', 'port', 'unix_socket'];
+			foreach ($optional as $el) {
+				if (isset($this->dsnarr[$el])) {
+					$connectionParams[$el] = $this->dsnarr[$el];
+				}
+			}
 			$this->dConn = DriverManager::getConnection($connectionParams);
 		}
 		return $this->dConn;

--- a/amp_conf/htdocs/admin/libraries/BMO/GuiHooks.class.php
+++ b/amp_conf/htdocs/admin/libraries/BMO/GuiHooks.class.php
@@ -74,7 +74,7 @@ class GuiHooks {
 	/**
 	 * Check for hooks for the current GUI function
 	 */
-	public function doGUIHooks($thispage = null, &$currentcomponent) {
+	public function doGUIHooks($thispage, &$currentcomponent) {
 		if (!$thispage)
 			return false;
 
@@ -136,7 +136,7 @@ class GuiHooks {
 				\modgettext::push_textdomain(strtolower($moduleToCall));
 				// Now, does the hook actually exist?
 				if (!method_exists($moduleToCall, "doGuiIntercept"))
-					throw new \Exception("$moduleToCall asked to intercept, but ${moduleToCall}->doGuiIntercept() doesn't exist");
+					throw new \Exception("$moduleToCall asked to intercept, but {$moduleToCall}->doGuiIntercept() doesn't exist");
 
 				// Output is being passed as a reference.
 				$mod->doGuiIntercept($filename, $output);


### PR DESCRIPTION
`host` and `port` are specifically unset earlier in the code when a socket is in use, and `unix_socket` is set. They also [don't need to be passed on to Doctrine](https://github.com/andreia/doctrine/blob/master/lib/Doctrine/DBAL/Driver/PDOMySql/Driver.php#L58) if they aren't set.

Also did a bit of basic cleanup, I assume MySQL 5.4 is not supported any more. (There is still a bunch of cleanup left in this file of course.)