### PR TITLE
Fix missing file errors when setting locale

### DIFF
--- a/amp_conf/htdocs/admin/libraries/BMO/View.class.php
+++ b/amp_conf/htdocs/admin/libraries/BMO/View.class.php
@@ -406,17 +406,18 @@ class View {
 		putenv('LANGUAGE='.$lang);
 		setlocale(LC_ALL, $lang);
 
+		// Moment and Carbon do not support UTF8 locale parts, so let's remove that from
+		// the locale string if it exists
+		$baseLocale = $this->getBaseLocale($lang);
+
 		//Set Carbon Locale
-		if(!Carbon::setLocale($lang)) {
-			$ps = explode("_",(string) $lang);
+		if(!Carbon::setLocale($baseLocale)) {
+			$ps = explode("_",(string) $baseLocale);
 			if(!Carbon::setLocale($ps[0])) {
 				Carbon::setLocale('en');
 			}
 		}
 
-		// Moment does not support UTF8 locale parts, so let's remove that from
-		// the locale string if it exists
-		$baseLocale = $this->getBaseLocale($lang);
 		try {
 			\Moment\Moment::setLocale($baseLocale);
 		} catch(\Exception) {


### PR DESCRIPTION
See files in `libraries/Composer/vendor/nesbot/carbon/src/Carbon/Lang/`; there are no files with utf8.

Resolves log entries from cron job being run every minute:
```none
[21-Feb-2024 12:54:30 America/Toronto] PHP Warning: include(/var/www/html/admin/libraries/Composer/vendor/nesbot/carbon/src/Carbon/Lang/en_US.utf8.php): Failed to open stream: No such file or directory in /var/www/html/admin/libraries/Composer/vendor/nesbot/carbon/src/Carbon/AbstractTranslator.php on line 163
[21-Feb-2024 12:54:30 America/Toronto] PHP Warning: include(): Failed opening '/var/www/html/admin/libraries/Composer/vendor/nesbot/carbon/src/Carbon/Lang/en_US.utf8.php' for inclusion (include_path='.:/usr/share/pear:/usr/share/php:/usr/local/lib/php') in /var/www/html/admin/libraries/Composer/vendor/nesbot/carbon/src/Carbon/AbstractTranslator.php on line 163
[21-Feb-2024 12:55:02 America/Toronto] PHP Warning: include(/var/www/html/admin/libraries/Composer/vendor/nesbot/carbon/src/Carbon/Lang/en_US.utf8.php): Failed to open stream: No such file or directory in /var/www/html/admin/libraries/Composer/vendor/nesbot/carbon/src/Carbon/AbstractTranslator.php on line 163
[21-Feb-2024 12:55:02 America/Toronto] PHP Warning: include(): Failed opening '/var/www/html/admin/libraries/Composer/vendor/nesbot/carbon/src/Carbon/Lang/en_US.utf8.php' for inclusion (include_path='.:/usr/share/pear:/usr/share/php:/usr/local/lib/php') in /var/www/html/admin/libraries/Composer/vendor/nesbot/carbon/src/Carbon/AbstractTranslator.php on line 163
[21-Feb-2024 12:56:01 America/Toronto] PHP Warning: include(/var/www/html/admin/libraries/Composer/vendor/nesbot/carbon/src/Carbon/Lang/en_US.utf8.php): Failed to open stream: No such file or directory in /var/www/html/admin/libraries/Composer/vendor/nesbot/carbon/src/Carbon/AbstractTranslator.php on line 163
[21-Feb-2024 12:56:01 America/Toronto] PHP Warning: include(): Failed opening '/var/www/html/admin/libraries/Composer/vendor/nesbot/carbon/src/Carbon/Lang/en_US.utf8.php' for inclusion (include_path='.:/usr/share/pear:/usr/share/php:/usr/local/lib/php') in /var/www/html/admin/libraries/Composer/vendor/nesbot/carbon/src/Carbon/AbstractTranslator.php on line 163
```