### PR TITLE
check files exist before operations

### DIFF
--- a/amp_conf/htdocs/admin/libraries/Console/Chown.class.php
+++ b/amp_conf/htdocs/admin/libraries/Console/Chown.class.php
@@ -433,6 +433,9 @@ class Chown extends Command {
 			if(!is_null($progress)) {
 				$progress->advance();
 			}
+			if(!file_exists($file)) {
+				continue;
+			}
 			if($this->checkBlacklist($file)){
 				$this->d(sprintf(_('%s skipped by configuration'), $file));
 				continue;
@@ -467,6 +470,9 @@ class Chown extends Command {
 		foreach ($this->toIterator($files) as $file) {
 			if(!is_null($progress)) {
 				$progress->advance();
+			}
+			if(!file_exists($file)) {
+				continue;
 			}
 			if($this->checkBlacklist($file)){
 				$this->d(sprintf(_('%s skipped by configuration'), $file));
@@ -504,6 +510,9 @@ class Chown extends Command {
 		foreach ($this->toIterator($files) as $file) {
 			if(!is_null($progress)) {
 				$progress->advance();
+			}
+			if(!file_exists($file)) {
+				continue;
 			}
 			if($this->checkBlacklist($file)){
 				$this->d(sprintf(_('%s skipped by configuration'), $file));


### PR DESCRIPTION
It's possible invalid file entries might be added to `freepbx_chown.conf` or internal module lists. Before wasting time on them, check if they exist. I don't think this warrants any kind of error message. This could also be backported to 16.