### PR TITLE
Update form_helper.php

### DIFF
--- a/amp_conf/htdocs/admin/helpers/form_helper.php
+++ b/amp_conf/htdocs/admin/helpers/form_helper.php
@@ -634,6 +634,11 @@ if ( ! function_exists('form_prep'))
 			return '';
 		}
 
+		if ($str === NULL)
+		{
+			return '';
+		}
+
 		// we've already prepped a field with this name
 		// @todo need to figure out a way to namespace this so
 		// that we know the *exact* field and not just one with


### PR DESCRIPTION
[bug]: form_helper.php - form_prep if $str is null in htmlspecialchars (deprecated since php 8.1) #149