### PR TITLE
Correct typo (now blocking when using dynroute mysql source)

### DIFF
--- a/amp_conf/htdocs/admin/libraries/extensions.class.php
+++ b/amp_conf/htdocs/admin/libraries/extensions.class.php
@@ -1564,7 +1564,7 @@ class ext_mysql_query extends extension {
 class ext_mysql_fetch extends extension {
 	var $fetchid;
 	var $resultid;
-	var $fars;
+	var $vars;
 
 	function __construct($fetchid, $resultid, $vars) {
 		$this->fetchid = $fetchid;


### PR DESCRIPTION
Correcting 18 year old typo. The code stopped working after deprecation of php class dynamic properties which had enabled the code to work despite the typo