### PR TITLE
Adding check if dsn port is already defined before loading defaults

### DIFF
--- a/amp_conf/htdocs/admin/libraries/BMO/Database.class.php
+++ b/amp_conf/htdocs/admin/libraries/BMO/Database.class.php
@@ -92,14 +92,16 @@ class Database extends \PDO {
 
 		$engine = ($engine == 'mariadb') ? 'mysql' : $engine;
 
-		$dsnarr['port'] = '3306'; // initialize with default port
+		if(!array_key_exists('port', $dsnarr) || $dsnarr['port'] == ''  || $dsnarr['port'] == 0) {
+			$dsnarr['port'] = '3306'; // initialize with default port
 
-		// We only want to add port to the DSN if it's actually defined.
-		if (isset($amp_conf['AMPDBPORT'])) {
-			// Make sure this is an int
-			$port = (int) $amp_conf['AMPDBPORT'];
-			if ($port > 1024) {
-				$dsnarr['port'] = $port;
+			// We only want to add port to the DSN if it's actually defined.
+			if (isset($amp_conf['AMPDBPORT'])) {
+					// Make sure this is an int
+					$port = (int) $amp_conf['AMPDBPORT'];
+					if ($port > 1024) {
+							$dsnarr['port'] = $port;
+					}
 			}
 		}
 


### PR DESCRIPTION
This fixes the problem in https://github.com/FreePBX/issue-tracker/issues/499

Specifically for the database connection for the CDR, the setting from the configuration is ignored and the default is loaded.

In this case, if the port is already supplied, use it.