### PR TITLE
Update functions.inc.php

### DIFF
--- a/amp_conf/htdocs/admin/functions.inc.php
+++ b/amp_conf/htdocs/admin/functions.inc.php
@@ -322,8 +322,8 @@ function engine_getinfo($force_read=false) {
 			} elseif (preg_match('/Asterisk [C].(\d+(\.\d+)*)(-?(\S*))/', $verinfo, $matches)) {
 				$engine_info = array('engine'=>'asterisk', 'version' => '1.4', 'additional' => $matches[3], 'raw' => $verinfo);
 				$gotinfo = true;
-												} elseif (preg_match('/Asterisk certified\/(\d+(\.\d+)*)(-?(\S*))/', $verinfo, $matches)) {
-																$engine_info = array('engine'=>'asterisk', 'version' => $matches[1] . $matches[3], 'additional' => $matches[3], 'raw' => $verinfo);
+			} elseif (preg_match('/Asterisk certified\-(\d+(\.\d+)*)(-?(\S*))/', $verinfo, $matches)) {
+				$engine_info = array('engine'=>'asterisk', 'version' => $matches[1] . $matches[3], 'additional' => $matches[3], 'raw' => $verinfo);
 				$gotinfo = true;
 			}
 


### PR DESCRIPTION
There is an error in the engine identification which doesn't allow to install or use the FreePBX 17 with the latest Asterisk Certified version. The error message appears in the FreePBX web UI:
Unknown Error. Please Run: fwconsole reload --verbose 

asterisk -V:
Asterisk certified-20.7-cert3

Patch to correct compatibility with Asterisk Certified 20.7-Cert3