### PR TITLE
Use empty() to avoid undefined var error during bootstrap

### DIFF
--- a/amp_conf/htdocs/admin/libraries/gui_auth.php
+++ b/amp_conf/htdocs/admin/libraries/gui_auth.php
@@ -18,7 +18,7 @@ if (!isset($_SESSION['AMP_user'])) {
 	 }
 	//|| (isset($_SESSION['AMP_user']->username) && $_SESSION['AMP_user']->username != $_SERVER['PHP_AUTH_USER'])) {
 	//if we dont have a username/pass prompt for one
-	if (!$username || !$password) {
+	if (empty($username) || empty($password)) {
 		switch(strtolower($amp_conf['AUTHTYPE'])) {
 			case 'usermanager':
 			case 'database':


### PR DESCRIPTION
On a FreePBX 17 PHP 8.2 system, I was getting an undefined variable (username) error [on line 21 of gui_auth.php](https://github.com/FreePBX/framework/blob/3f3148e32b774ba7c53ffe35c3ce06cddc1ec174/amp_conf/htdocs/admin/libraries/gui_auth.php#L21C6-L21C16) when called by bootstrap.php.

Using empty() is a safer way to check for the existence of the username and password variable.

I'm running this in production with no issue.