### PR TITLE
OOBE typo in label for System Notifications Email.

### DIFF
--- a/amp_conf/htdocs/admin/i18n/amp.pot
+++ b/amp_conf/htdocs/admin/i18n/amp.pot
@@ -10750,7 +10750,7 @@ msgid "System Identity"
 msgstr ""
 
 #: amp_conf/htdocs/admin/views/oobe.php:112
-msgid "System Notifcations Email"
+msgid "System Notifications Email"
 msgstr ""
 
 #: amp.i18n.php:678

--- a/amp_conf/htdocs/admin/i18n/bg_BG/LC_MESSAGES/amp.po
+++ b/amp_conf/htdocs/admin/i18n/bg_BG/LC_MESSAGES/amp.po
@@ -10557,7 +10557,7 @@ msgid "System Identity"
 msgstr ""
 
 #: amp_conf/htdocs/admin/views/oobe.php:112
-msgid "System Notifcations Email"
+msgid "System Notifications Email"
 msgstr ""
 
 #: amp.i18n.php:678 ../core/install.php:444

--- a/amp_conf/htdocs/admin/i18n/cs/LC_MESSAGES/amp.po
+++ b/amp_conf/htdocs/admin/i18n/cs/LC_MESSAGES/amp.po
@@ -10454,7 +10454,7 @@ msgid "System Identity"
 msgstr ""
 
 #: amp_conf/htdocs/admin/views/oobe.php:112
-msgid "System Notifcations Email"
+msgid "System Notifications Email"
 msgstr ""
 
 #: amp.i18n.php:678 ../core/install.php:444

--- a/amp_conf/htdocs/admin/i18n/de_DE/LC_MESSAGES/amp.po
+++ b/amp_conf/htdocs/admin/i18n/de_DE/LC_MESSAGES/amp.po
@@ -10576,7 +10576,7 @@ msgid "System Identity"
 msgstr ""
 
 #: amp_conf/htdocs/admin/views/oobe.php:112
-msgid "System Notifcations Email"
+msgid "System Notifications Email"
 msgstr ""
 
 #: amp.i18n.php:678 ../core/install.php:444

--- a/amp_conf/htdocs/admin/i18n/es_ES/LC_MESSAGES/amp.po
+++ b/amp_conf/htdocs/admin/i18n/es_ES/LC_MESSAGES/amp.po
@@ -10434,7 +10434,7 @@ msgid "System Identity"
 msgstr ""
 
 #: amp_conf/htdocs/admin/views/oobe.php:112
-msgid "System Notifcations Email"
+msgid "System Notifications Email"
 msgstr ""
 
 #: amp.i18n.php:678 ../core/install.php:444

--- a/amp_conf/htdocs/admin/i18n/fa_IR/LC_MESSAGES/amp.po
+++ b/amp_conf/htdocs/admin/i18n/fa_IR/LC_MESSAGES/amp.po
@@ -11148,7 +11148,7 @@ msgid "System Identity"
 msgstr "هویت سیستم"
 
 #: amp_conf/htdocs/admin/views/oobe.php:112
-msgid "System Notifcations Email"
+msgid "System Notifications Email"
 msgstr ""
 
 #: amp.i18n.php:678 ../core/install.php:444

--- a/amp_conf/htdocs/admin/i18n/fr_FR/LC_MESSAGES/amp.po
+++ b/amp_conf/htdocs/admin/i18n/fr_FR/LC_MESSAGES/amp.po
@@ -10638,7 +10638,7 @@ msgid "System Identity"
 msgstr "Identité système"
 
 #: amp_conf/htdocs/admin/views/oobe.php:112
-msgid "System Notifcations Email"
+msgid "System Notifications Email"
 msgstr ""
 
 #: amp.i18n.php:678 ../core/install.php:444

--- a/amp_conf/htdocs/admin/i18n/he_IL/LC_MESSAGES/amp.po
+++ b/amp_conf/htdocs/admin/i18n/he_IL/LC_MESSAGES/amp.po
@@ -10448,7 +10448,7 @@ msgid "System Identity"
 msgstr ""
 
 #: amp_conf/htdocs/admin/views/oobe.php:112
-msgid "System Notifcations Email"
+msgid "System Notifications Email"
 msgstr ""
 
 #: amp.i18n.php:678 ../core/install.php:444

--- a/amp_conf/htdocs/admin/i18n/hu_HU/LC_MESSAGES/amp.po
+++ b/amp_conf/htdocs/admin/i18n/hu_HU/LC_MESSAGES/amp.po
@@ -10466,7 +10466,7 @@ msgid "System Identity"
 msgstr ""
 
 #: amp_conf/htdocs/admin/views/oobe.php:112
-msgid "System Notifcations Email"
+msgid "System Notifications Email"
 msgstr ""
 
 #: amp.i18n.php:678 ../core/install.php:444

--- a/amp_conf/htdocs/admin/i18n/it_IT/LC_MESSAGES/amp.po
+++ b/amp_conf/htdocs/admin/i18n/it_IT/LC_MESSAGES/amp.po
@@ -10491,7 +10491,7 @@ msgid "System Identity"
 msgstr ""
 
 #: amp_conf/htdocs/admin/views/oobe.php:112
-msgid "System Notifcations Email"
+msgid "System Notifications Email"
 msgstr ""
 
 #: amp.i18n.php:678 ../core/install.php:444

--- a/amp_conf/htdocs/admin/i18n/ja_JP/LC_MESSAGES/amp.po
+++ b/amp_conf/htdocs/admin/i18n/ja_JP/LC_MESSAGES/amp.po
@@ -10990,7 +10990,7 @@ msgid "System Identity"
 msgstr ""
 
 #: amp_conf/htdocs/admin/views/oobe.php:112
-msgid "System Notifcations Email"
+msgid "System Notifications Email"
 msgstr ""
 
 #: amp.i18n.php:678 ../core/install.php:444

--- a/amp_conf/htdocs/admin/i18n/nl_NL/LC_MESSAGES/amp.po
+++ b/amp_conf/htdocs/admin/i18n/nl_NL/LC_MESSAGES/amp.po
@@ -10592,7 +10592,7 @@ msgid "System Identity"
 msgstr ""
 
 #: amp_conf/htdocs/admin/views/oobe.php:112
-msgid "System Notifcations Email"
+msgid "System Notifications Email"
 msgstr ""
 
 #: amp.i18n.php:678 ../core/install.php:444

--- a/amp_conf/htdocs/admin/i18n/pl/LC_MESSAGES/amp.po
+++ b/amp_conf/htdocs/admin/i18n/pl/LC_MESSAGES/amp.po
@@ -10656,7 +10656,7 @@ msgid "System Identity"
 msgstr ""
 
 #: amp_conf/htdocs/admin/views/oobe.php:112
-msgid "System Notifcations Email"
+msgid "System Notifications Email"
 msgstr ""
 
 #: amp.i18n.php:678 ../core/install.php:444

--- a/amp_conf/htdocs/admin/i18n/pt_BR/LC_MESSAGES/amp.po
+++ b/amp_conf/htdocs/admin/i18n/pt_BR/LC_MESSAGES/amp.po
@@ -11307,7 +11307,7 @@ msgid "System Identity"
 msgstr "Identidade do Sistema"
 
 #: amp_conf/htdocs/admin/views/oobe.php:112
-msgid "System Notifcations Email"
+msgid "System Notifications Email"
 msgstr ""
 
 #: amp.i18n.php:678 ../core/install.php:444

--- a/amp_conf/htdocs/admin/i18n/pt_PT/LC_MESSAGES/amp.po
+++ b/amp_conf/htdocs/admin/i18n/pt_PT/LC_MESSAGES/amp.po
@@ -10668,7 +10668,7 @@ msgid "System Identity"
 msgstr ""
 
 #: amp_conf/htdocs/admin/views/oobe.php:112
-msgid "System Notifcations Email"
+msgid "System Notifications Email"
 msgstr ""
 
 #: amp.i18n.php:678 ../core/install.php:444

--- a/amp_conf/htdocs/admin/i18n/ro_RO/LC_MESSAGES/amp.po
+++ b/amp_conf/htdocs/admin/i18n/ro_RO/LC_MESSAGES/amp.po
@@ -10563,7 +10563,7 @@ msgid "System Identity"
 msgstr ""
 
 #: amp_conf/htdocs/admin/views/oobe.php:112
-msgid "System Notifcations Email"
+msgid "System Notifications Email"
 msgstr ""
 
 #: amp.i18n.php:678 ../core/install.php:444

--- a/amp_conf/htdocs/admin/i18n/ru_RU/LC_MESSAGES/amp.po
+++ b/amp_conf/htdocs/admin/i18n/ru_RU/LC_MESSAGES/amp.po
@@ -11162,7 +11162,7 @@ msgid "System Identity"
 msgstr ""
 
 #: amp_conf/htdocs/admin/views/oobe.php:112
-msgid "System Notifcations Email"
+msgid "System Notifications Email"
 msgstr ""
 
 #: amp.i18n.php:678 ../core/install.php:444

--- a/amp_conf/htdocs/admin/i18n/sv_SE/LC_MESSAGES/amp.po
+++ b/amp_conf/htdocs/admin/i18n/sv_SE/LC_MESSAGES/amp.po
@@ -10576,7 +10576,7 @@ msgid "System Identity"
 msgstr ""
 
 #: amp_conf/htdocs/admin/views/oobe.php:112
-msgid "System Notifcations Email"
+msgid "System Notifications Email"
 msgstr ""
 
 #: amp.i18n.php:678 ../core/install.php:444

--- a/amp_conf/htdocs/admin/i18n/uk_UA/LC_MESSAGES/amp.po
+++ b/amp_conf/htdocs/admin/i18n/uk_UA/LC_MESSAGES/amp.po
@@ -10479,7 +10479,7 @@ msgid "System Identity"
 msgstr ""
 
 #: amp_conf/htdocs/admin/views/oobe.php:112
-msgid "System Notifcations Email"
+msgid "System Notifications Email"
 msgstr ""
 
 #: amp.i18n.php:678 ../core/install.php:444

--- a/amp_conf/htdocs/admin/i18n/vi/LC_MESSAGES/amp.po
+++ b/amp_conf/htdocs/admin/i18n/vi/LC_MESSAGES/amp.po
@@ -10455,7 +10455,7 @@ msgid "System Identity"
 msgstr ""
 
 #: amp_conf/htdocs/admin/views/oobe.php:112
-msgid "System Notifcations Email"
+msgid "System Notifications Email"
 msgstr ""
 
 #: amp.i18n.php:678 ../core/install.php:444

--- a/amp_conf/htdocs/admin/i18n/zh_CN/LC_MESSAGES/amp.po
+++ b/amp_conf/htdocs/admin/i18n/zh_CN/LC_MESSAGES/amp.po
@@ -10544,7 +10544,7 @@ msgid "System Identity"
 msgstr ""
 
 #: amp_conf/htdocs/admin/views/oobe.php:112
-msgid "System Notifcations Email"
+msgid "System Notifications Email"
 msgstr ""
 
 #: amp.i18n.php:678 ../core/install.php:444

--- a/amp_conf/htdocs/admin/views/oobe.php
+++ b/amp_conf/htdocs/admin/views/oobe.php
@@ -109,7 +109,7 @@ if (!isset($system_ident)) {
           </div>
         </div>
       </div>
-      <h3 class="text-center"><?php echo _("System Notifcations Email")?></h3>
+      <h3 class="text-center"><?php echo _("System Notifications Email")?></h3>
       <div class=''>
         <div class='row form-group'>
           <div class='col-sm-3'>


### PR DESCRIPTION
Add an i to Notifcations to spell Notifications properly with three i's instead of two. Applied to translation keys as well.

Bugfix FreePBX/issue-tracker#601