### PR TITLE
Issue-650 Custom Context no Delete Button

### DIFF
--- a/amp_conf/htdocs/admin/libraries/components.class.php
+++ b/amp_conf/htdocs/admin/libraries/components.class.php
@@ -372,7 +372,7 @@ class component {
 		}
 		$this->generated = true;
 
-		$htmlout = '';
+		$active = $htmlout = '';
 		$formname = "frm_$this->compname";
 		$hasoutput = false;
 


### PR DESCRIPTION
This PR will fix the undefined error that occurs when we try to delete the custom context.

![Screenshot 2025-02-13 173240](https://github.com/user-attachments/assets/c5903ebf-69bb-40dd-baea-836c8c4deb9e)


Note: Custom Context has a Delete Button when we try to edit the context.

![Screenshot 2025-02-13 173131](https://github.com/user-attachments/assets/cdaa2b4d-cab8-40e2-98e2-363091b8aad7)
