### PR TITLE
fix foreign key creation from module.xml

### DIFF
--- a/amp_conf/htdocs/admin/libraries/BMO/Database/Migration.class.php
+++ b/amp_conf/htdocs/admin/libraries/BMO/Database/Migration.class.php
@@ -1,5 +1,4 @@
 <?php
-// vim: set ai ts=4 sw=4 ft=php:
 /**
  * This is the FreePBX Big Module Object.
  *
@@ -7,211 +6,220 @@
  * License for all code of this FreePBX module can be found in the license file inside the module directory
  * Copyright 2006-2014 Schmooze Com Inc.
  */
+
 namespace FreePBX\Database;
-use Doctrine\DBAL\Schema\SchemaConfig;
+
 use Doctrine\DBAL\Schema\Comparator;
 use Doctrine\DBAL\Schema\Schema;
-use Doctrine\DBAL\Schema\Synchronizer\SingleDatabaseSynchronizer;
-class Migration {
-	private $conn;
-	private $table;
-	private $version;
-	private $driver;
+use Doctrine\DBAL\Schema\SchemaConfig;
+use Exception;
+use FreePBX\Database\DBAL\SingleDatabaseSynchronizer;
 
-	public function __construct($conn, $version, $driverName) {
-		$this->conn = $conn;
-		$this->version = $version;
-		$this->driver =  $driverName;
-		//http://wildlyinaccurate.com/doctrine-2-resolving-unknown-database-type-enum-requested/
-		$this->conn->getDatabasePlatform()->registerDoctrineTypeMapping('enum', 'string');
-	}
+class Migration
+{
+    private $conn;
+    private $table;
+    private $version;
+    private $driver;
 
-	public function setTable($table) {
-		$this->table = trim($table);
-	}
+    public function __construct($conn, $version, $driverName)
+    {
+        $this->conn = $conn;
+        $this->version = $version;
+        $this->driver =  $driverName;
+        // http://wildlyinaccurate.com/doctrine-2-resolving-unknown-database-type-enum-requested/
+        $this->conn->getDatabasePlatform()->registerDoctrineTypeMapping('enum', 'string');
+    }
 
-	/**
-	 * Generate Update Array used to create or update tables
-	 * @method generateUpdateArray
-	 * @return array              Array of table
-	 */
-	public function generateUpdateArray() {
-		if(empty($this->table)) {
-			throw new \Exception("Table not set!");
-		}
-		$sm = $this->conn->getSchemaManager();
-		$fromSchema = $sm->createSchema();
-		$schema = new Schema();
+    public function setTable($table)
+    {
+        $this->table = trim($table);
+    }
 
-		$diff = Comparator::compareSchemas($schema,$fromSchema);
-		if(!isset($diff->newTables[$this->table])) {
-			throw new \Exception("Table does not exist");
-		}
-		//$table = $sm->listTableDetails($this->table);
-		$columns = $sm->listTableColumns($this->table);
-		$foreignKeys = $sm->listTableForeignKeys($this->table);
-		$indexes = $sm->listTableIndexes($this->table);
+    /**
+     * Generate Update Array used to create or update tables
+     *
+     * @return array Array of table
+     */
+    public function generateUpdateArray()
+    {
+        if (empty($this->table)) {
+            throw new Exception('Table not set!');
+        }
+        $sm = $this->conn->getSchemaManager();
+        $fromSchema = $sm->createSchema();
+        $schema = new Schema();
 
-		$export = array();
-		$expindexes = array();
-		foreach ($columns as $column) {
-			$type = $column->getType()->getName();
-			$name = $column->getName();
-			switch($type) {
-				case 'string':
-					$export[$name]['type'] = $type;
-					$export[$name]['length'] = $column->getLength();
-				break;
-				case 'blob':
-				case 'integer':
-				case 'bigint':
-				case 'smallint':
-				case 'date':
-				case 'datetime':
-				case 'text':
-				case 'boolean':
-					$export[$name]['type'] = $type;
-				break;
-				case 'float':
-				case 'decimal':
-					$export[$name]['type'] = $type;
-					$export[$name]['precision'] = $column->getPrecision();
-					$export[$name]['scale'] = $column->getScale();
-				break;
-				default:
-					throw new \Exception("Unknown type: ".$type);
-				break;
-			}
-			if(!$column->getNotnull()) {
-				$export[$name]['notnull'] = $column->getNotnull();
-			}
-			if($column->getAutoincrement()) {
-				$export[$name]['autoincrement'] = $column->getAutoincrement();
-			}
-			if($column->getUnsigned()) {
-				$export[$name]['unsigned'] = $column->getUnsigned();
-			}
-			$default = $column->getDefault();
-			if(!in_array($type,array("datetime","datetime/timestamp")) && !is_null($default)){
-				$export[$name]['default'] = $default;
-			}
-		}
-		foreach ($indexes as $index) {
-			$name = $index->getName();
-			if($index->isPrimary()) {
-				foreach($index->getColumns() as $col) {
-					$export[$col]['primarykey'] = true;
-				}
-				continue;
-			} elseif($index->isUnique()) {
-				$expindexes[$name]['type'] = 'unique';
-			} else {
-				$expindexes[$name]['type'] = 'index';
-			}
-			$expindexes[$name]['cols'] = $index->getColumns();
-		}
+        $diff = Comparator::compareSchemas($schema,$fromSchema);
+        if (!isset($diff->newTables[$this->table])) {
+            throw new Exception('Table does not exist');
+        }
+        //$table = $sm->listTableDetails($this->table);
+        $columns = $sm->listTableColumns($this->table);
+        $foreignKeys = $sm->listTableForeignKeys($this->table);
+        $indexes = $sm->listTableIndexes($this->table);
 
-		if(!empty($foreignKeys)) {
-			throw new \Exception("There are foreign keys here. Cant accurately generate tables");
-		}
-		/*
-		foreach ($foreignKeys as $foreignKey) {
-			//echo $foreignKey->getName() . ': ' . $foreignKey->getLocalTableName() ."\n";
-		}
-		*/
+        $export = [];
+        $expindexes = [];
+        foreach ($columns as $column) {
+            $type = $column->getType()->getName();
+            $name = $column->getName();
+            switch ($type) {
+                case 'string':
+                    $export[$name]['type'] = $type;
+                    $export[$name]['length'] = $column->getLength();
+                    break;
+                case 'blob':
+                case 'integer':
+                case 'bigint':
+                case 'smallint':
+                case 'date':
+                case 'datetime':
+                case 'text':
+                case 'boolean':
+                    $export[$name]['type'] = $type;
+                    break;
+                case 'float':
+                case 'decimal':
+                    $export[$name]['type'] = $type;
+                    $export[$name]['precision'] = $column->getPrecision();
+                    $export[$name]['scale'] = $column->getScale();
+                    break;
+                default:
+                    throw new Exception('Unknown type: ' . $type);
+            }
+            if (!$column->getNotnull()) {
+                $export[$name]['notnull'] = $column->getNotnull();
+            }
+            if ($column->getAutoincrement()) {
+                $export[$name]['autoincrement'] = $column->getAutoincrement();
+            }
+            if ($column->getUnsigned()) {
+                $export[$name]['unsigned'] = $column->getUnsigned();
+            }
+            $default = $column->getDefault();
+            if (!in_array($type, ['datetime', 'datetime/timestamp']) && !is_null($default)) {
+                $export[$name]['default'] = $default;
+            }
+        }
+        foreach ($indexes as $index) {
+            $name = $index->getName();
+            if($index->isPrimary()) {
+                foreach ($index->getColumns() as $col) {
+                    $export[$col]['primarykey'] = true;
+                }
+                continue;
+            } elseif ($index->isUnique()) {
+                $expindexes[$name]['type'] = 'unique';
+            } else {
+                $expindexes[$name]['type'] = 'index';
+            }
+            $expindexes[$name]['cols'] = $index->getColumns();
+        }
 
-		return array("columns"=>$export, "indexes" => $expindexes);
-	}
+        if (!empty($foreignKeys)) {
+            throw new Exception('There are foreign keys here. Cant accurately generate tables');
+        }
+        /*
+        foreach ($foreignKeys as $foreignKey) {
+            //echo $foreignKey->getName() . ': ' . $foreignKey->getLocalTableName() .'\n';
+        }
+        */
 
-	/**
-	 * Modify Multiple Tables
-	 * @method modify
-	 * @param  array  $tables  The tables to update
-	 * @param  bool   $dryrun  If set to true dont execute just return the sql modification string
-	 * @return mixed
-	 */
-	public function modifyMultiple($tables=array(),$dryrun=false) {
-		$synchronizer = new \FreePBX\Database\DBAL\SingleDatabaseSynchronizer($this->conn);
-		$schemaConfig = new SchemaConfig();
-		if($this->driver == "pdo_mysql" && version_compare($this->version, "5.5.3", "ge")) {
-			$schemaConfig->setDefaultTableOptions(array(
-				"collate"=>"utf8mb4_unicode_ci",
-				"charset"=>"utf8mb4"
-			));
-		}
-		$schema = new Schema(array(),array(),$schemaConfig);
-		foreach($tables as $tname => $tdata) {
-			$table = $schema->createTable($tname);
-			$primaryKeys = array();
-			foreach($tdata['columns'] as $name => $options) {
-				$type = $options['type'];
-				unset($options['type']);
-				$pk = isset($options['primaryKey']) ? $options['primaryKey'] : (isset($options['primarykey']) ? $options['primarykey'] : null);
-				if(!is_null($pk)) {
-					if($pk) {
-						$primaryKeys[] = $name;
-						if(isset($options['primaryKey'])) {
-							unset($options['primaryKey']);
-						}else if(isset($options['primarykey'])){ 
-							unset($options['primarykey']);
-						}
-					}
-				}
-				$table->addColumn($name, $type, $options);
-			}
-			if(!empty($primaryKeys)) {
-				$table->setPrimaryKey($primaryKeys);
-			}
-			if(!empty($tdata['indexes']) && is_array($tdata['indexes'])) {
-				foreach($tdata['indexes'] as $name => $data) {
-					$type = $data['type'];
-					$columns = $data['cols'];
-					switch($type) {
-						case "unique":
-							$table->addUniqueIndex($columns,$name);
-						break;
-						case "index":
-							$table->addIndex($columns,$name);
-						break;
-						case "fulltext":
-							if($this->driver == "pdo_mysql" && version_compare($this->version, "5.6", "le")) {
-								$table->addOption('engine' , 'MyISAM');
-							}
-							$table->addIndex($columns,$name,array("fulltext"));
-						break;
-						case "foreign":
-							$table->addForeignKeyConstraint($data['foreigntable'], $columns, $data['foreigncols'], $data['options'], $name);
-						break;
-					}
-				}
-			}
-		}
-		//with true to prevent drops
-		if($dryrun) {
-			return $synchronizer->getUpdateSchema($schema, true);
-		} else {
-			return $synchronizer->updateSchema($schema, true);
-		}
-	}
+        return ['columns' => $export, 'indexes' => $expindexes];
+    }
 
-	/**
-	 * Modify Single Table
-	 * @method modify
-	 * @param  array  $columns Columns to update
-	 * @param  array  $indexes Indexes to update
-	 * @param  bool   $dryrun  If set to true dont execute just return the sql modification string
-	 * @return mixed
-	 */
-	public function modify($columns=array(),$indexes=array(),$dryrun=false) {
-		if(empty($this->table)) {
-			throw new \Exception("Table not set!");
-		}
-		$table = $this->table;
-		return $this->modifyMultiple(array(
-			$table => array(
-				'columns' => $columns,
-				'indexes' => $indexes
-			)
-		),$dryrun);
-	}
+    /**
+     * Modify Multiple Tables
+     *
+     * @param  array  $tables  The tables to update
+     * @param  bool   $dryrun  If set to true dont execute just return the sql modification string
+     * @return mixed
+     */
+    public function modifyMultiple($tables = [], $dryrun = false)
+    {
+        $synchronizer = new SingleDatabaseSynchronizer($this->conn);
+        $schemaConfig = new SchemaConfig();
+        if ($this->driver === 'pdo_mysql' && version_compare($this->version, '5.5.3', 'ge')) {
+            $schemaConfig->setDefaultTableOptions([
+                'collate' => 'utf8mb4_unicode_ci',
+                'charset' => 'utf8mb4',
+            ]);
+        }
+        $schema = new Schema([], [], $schemaConfig);
+        foreach ($tables as $tname => $tdata) {
+            $table = $schema->createTable($tname);
+            $primaryKeys = [];
+            foreach ($tdata['columns'] as $name => $options) {
+                $type = $options['type'];
+                unset($options['type']);
+                $pk = $options['primaryKey'] ?? $options['primarykey'] ?? null;
+                if(!is_null($pk)) {
+                    if ($pk) {
+                        $primaryKeys[] = $name;
+                        if (isset($options['primaryKey'])) {
+                            unset($options['primaryKey']);
+                        } elseif (isset($options['primarykey'])) { 
+                            unset($options['primarykey']);
+                        }
+                    }
+                }
+                $table->addColumn($name, $type, $options);
+            }
+            if (!empty($primaryKeys)) {
+                $table->setPrimaryKey($primaryKeys);
+            }
+            if (!empty($tdata['indexes']) && is_array($tdata['indexes'])) {
+                foreach ($tdata['indexes'] as $name => $data) {
+                    $type = $data['type'];
+                    $columns = $data['cols'];
+                    switch ($type) {
+                        case 'unique':
+                            $table->addUniqueIndex($columns, $name);
+                            break;
+                        case 'index':
+                            $table->addIndex($columns, $name);
+                            break;
+                        case 'fulltext':
+                            if($this->driver == 'pdo_mysql' && version_compare($this->version, '5.6', 'le')) {
+                                $table->addOption('engine', 'MyISAM');
+                            }
+                            $table->addIndex($columns,$name,array('fulltext'));
+                            break;
+                        case 'foreign':
+                            $table->addForeignKeyConstraint($data['foreigntable'], $columns, $data['foreigncols'], $data['options'], $name);
+                            break;
+                    }
+                }
+            }
+        }
+        //with true to prevent drops
+        if ($dryrun) {
+            return $synchronizer->getUpdateSchema($schema, true);
+        } else {
+            return $synchronizer->updateSchema($schema, true);
+        }
+    }
+
+    /**
+     * Modify Single Table
+     *
+     * @param  array  $columns Columns to update
+     * @param  array  $indexes Indexes to update
+     * @param  bool   $dryrun  If set to true dont execute just return the sql modification string
+     * @return mixed
+     */
+    public function modify($columns = [], $indexes = [], $dryrun=false)
+    {
+        if (empty($this->table)) {
+            throw new Exception('Table not set!');
+        }
+        $table = $this->table;
+        return $this->modifyMultiple([
+            $table => [
+                'columns' => $columns,
+                'indexes' => $indexes,
+            ]
+        ], $dryrun);
+    }
 }

--- a/amp_conf/htdocs/admin/libraries/BMO/Database/Migration.class.php
+++ b/amp_conf/htdocs/admin/libraries/BMO/Database/Migration.class.php
@@ -9,9 +9,9 @@
 
 namespace FreePBX\Database;
 
+use Doctrine\DBAL\Schema\SchemaConfig;
 use Doctrine\DBAL\Schema\Comparator;
 use Doctrine\DBAL\Schema\Schema;
-use Doctrine\DBAL\Schema\SchemaConfig;
 use Exception;
 use FreePBX\Database\DBAL\SingleDatabaseSynchronizer;
 
@@ -19,14 +19,10 @@ class Migration
 {
     private $conn;
     private $table;
-    private $version;
-    private $driver;
 
-    public function __construct($conn, $version, $driverName)
+    public function __construct($conn)
     {
         $this->conn = $conn;
-        $this->version = $version;
-        $this->driver =  $driverName;
         // http://wildlyinaccurate.com/doctrine-2-resolving-unknown-database-type-enum-requested/
         $this->conn->getDatabasePlatform()->registerDoctrineTypeMapping('enum', 'string');
     }
@@ -54,7 +50,6 @@ class Migration
         if (!isset($diff->newTables[$this->table])) {
             throw new Exception('Table does not exist');
         }
-        //$table = $sm->listTableDetails($this->table);
         $columns = $sm->listTableColumns($this->table);
         $foreignKeys = $sm->listTableForeignKeys($this->table);
         $indexes = $sm->listTableIndexes($this->table);
@@ -120,11 +115,6 @@ class Migration
         if (!empty($foreignKeys)) {
             throw new Exception('There are foreign keys here. Cant accurately generate tables');
         }
-        /*
-        foreach ($foreignKeys as $foreignKey) {
-            //echo $foreignKey->getName() . ': ' . $foreignKey->getLocalTableName() .'\n';
-        }
-        */
 
         return ['columns' => $export, 'indexes' => $expindexes];
     }
@@ -140,12 +130,10 @@ class Migration
     {
         $synchronizer = new SingleDatabaseSynchronizer($this->conn);
         $schemaConfig = new SchemaConfig();
-        if ($this->driver === 'pdo_mysql' && version_compare($this->version, '5.5.3', 'ge')) {
-            $schemaConfig->setDefaultTableOptions([
-                'collate' => 'utf8mb4_unicode_ci',
-                'charset' => 'utf8mb4',
-            ]);
-        }
+        $schemaConfig->setDefaultTableOptions([
+            'collate' => 'utf8mb4_unicode_ci',
+            'charset' => 'utf8mb4',
+        ]);
         $schema = new Schema([], [], $schemaConfig);
         foreach ($tables as $tname => $tdata) {
             $table = $schema->createTable($tname);
@@ -153,47 +141,41 @@ class Migration
             foreach ($tdata['columns'] as $name => $options) {
                 $type = $options['type'];
                 unset($options['type']);
-                $pk = $options['primaryKey'] ?? $options['primarykey'] ?? null;
-                if(!is_null($pk)) {
-                    if ($pk) {
-                        $primaryKeys[] = $name;
-                        if (isset($options['primaryKey'])) {
-                            unset($options['primaryKey']);
-                        } elseif (isset($options['primarykey'])) { 
-                            unset($options['primarykey']);
-                        }
-                    }
+                if ($options['primaryKey'] ?? $options['primarykey'] ?? null) {
+                    $primaryKeys[] = $name;
+                    unset($options['primaryKey'], $options['primarykey']);
                 }
                 $table->addColumn($name, $type, $options);
             }
             if (!empty($primaryKeys)) {
                 $table->setPrimaryKey($primaryKeys);
             }
-            if (!empty($tdata['indexes']) && is_array($tdata['indexes'])) {
-                foreach ($tdata['indexes'] as $name => $data) {
-                    $type = $data['type'];
-                    $columns = $data['cols'];
-                    switch ($type) {
-                        case 'unique':
-                            $table->addUniqueIndex($columns, $name);
-                            break;
-                        case 'index':
-                            $table->addIndex($columns, $name);
-                            break;
-                        case 'fulltext':
-                            if($this->driver == 'pdo_mysql' && version_compare($this->version, '5.6', 'le')) {
-                                $table->addOption('engine', 'MyISAM');
-                            }
-                            $table->addIndex($columns,$name,array('fulltext'));
-                            break;
-                        case 'foreign':
-                            $table->addForeignKeyConstraint($data['foreigntable'], $columns, $data['foreigncols'], $data['options'], $name);
-                            break;
-                    }
+            foreach ($tdata['indexes'] ?? [] as $name => $data) {
+                $type = $data['type'];
+                $columns = $data['cols'];
+                switch ($type) {
+                    case 'unique':
+                        $table->addUniqueIndex($columns, $name);
+                        break;
+                    case 'index':
+                        $table->addIndex($columns, $name);
+                        break;
+                    case 'fulltext':
+                        $table->addIndex($columns, $name, ['fulltext']);
+                        break;
+                    case 'foreign':
+                        $opts = [
+                            'onUpdate' => $data['onUpdate'] ?? $data['onupdate'] ?? null,
+                            'onDelete' => $data['onDelete'] ?? $data['ondelete'] ?? null,
+                        ];
+                        $opts = array_filter($opts);
+                        $foreigncols = array_map('trim', explode(',', $data['foreigncols']));
+                        $table->addForeignKeyConstraint($data['foreigntable'], $columns, $foreigncols, $opts, $name);
+                        break;
                 }
             }
         }
-        //with true to prevent drops
+        // with true to prevent drops
         if ($dryrun) {
             return $synchronizer->getUpdateSchema($schema, true);
         } else {
@@ -209,7 +191,7 @@ class Migration
      * @param  bool   $dryrun  If set to true dont execute just return the sql modification string
      * @return mixed
      */
-    public function modify($columns = [], $indexes = [], $dryrun=false)
+    public function modify($columns = [], $indexes = [], $dryrun = false)
     {
         if (empty($this->table)) {
             throw new Exception('Table not set!');

--- a/amp_conf/htdocs/admin/libraries/modulefunctions.class.php
+++ b/amp_conf/htdocs/admin/libraries/modulefunctions.class.php
@@ -2282,9 +2282,11 @@ class module_functions {
 				foreach($xml->database->table as $table) {
 					$tname = (string)$table->attributes()->name;
 					outn(sprintf(_("Dropping table %s..."),$tname));
+					FreePBX::Database()->query("SET FOREIGN_KEY_CHECKS=0");
 					$sth = FreePBX::Database()->prepare("DROP TABLE IF EXISTS ".$tname);
-					out(_("Done"));
 					$sth->execute();
+					FreePBX::Database()->query("SET FOREIGN_KEY_CHECKS=1");
+					out(_("Done"));
 				}
 			}
 		}


### PR DESCRIPTION
Resolves [FreePBX/issue-tracker #761 ](https://github.com/FreePBX/issue-tracker/issues/761) by passing arrays to Doctrine's FK creation method. This syntax doesn't seem to be documented anywhere so no updates to documentation needed? (hint: it probably should be documented somewhere)

Also took the opportunity to clean up the code a bit and remove some checks that were a) outdated and b) preventing proper character sets from being applied ("pdo_mysql" is not used in DSN strings, and safe to say nobody is using MySQL 5.5 any more.)

I know it looks like I rewrote the entire file, but view the diff with whitespace changes hidden and it will look a lot more reasonable!