### PR TITLE
Php Version Mismatch

### DIFF
--- a/amp_conf/htdocs/admin/helpers/Email.php
+++ b/amp_conf/htdocs/admin/helpers/Email.php
@@ -1577,11 +1577,6 @@ class CI_Email {
 
 		$status = pclose($fp);
 
-		if (version_compare(PHP_VERSION, '4.2.3') == -1)
-		{
-			$status = $status >> 8 & 0xFF;
-		}
-
 		if ($status != 0)
 		{
 			$this->_set_error_message('email_exit_status', $status);

--- a/amp_conf/htdocs/admin/libraries/Composer/composer.json
+++ b/amp_conf/htdocs/admin/libraries/Composer/composer.json
@@ -59,7 +59,7 @@
 	},
 	"config": {
 		"platform": {
-			"php": "8.1.0"
+			"php": "8.2.29"
 		},
 		"autoloader-suffix": "pbxframework",
 		"optimize-autoloader": true

--- a/install
+++ b/install
@@ -2,8 +2,8 @@
 <?php
 namespace FreePBX\Install;
 
-if (version_compare(PHP_VERSION, '7.4', '<')) {
-	echo "FreePBX Requires PHP Version 7.4 or Higher, you have: ".PHP_VERSION."\n";
+if (version_compare(PHP_VERSION, '8.2', '<')) {
+	echo "FreePBX Requires PHP Version 8.2 or Higher, you have: ".PHP_VERSION."\n";
 	return false;
 }
 

--- a/install.php
+++ b/install.php
@@ -1,8 +1,8 @@
 <?php
 if (!defined('FREEPBX_IS_AUTH')) { die('No direct script access allowed'); }
 
-if (version_compare(PHP_VERSION, '7.4', '<')) {
-	out(sprintf(_("FreePBX Requires PHP Version 7.4 or Higher, you have: %s"),PHP_VERSION));
+if (version_compare(PHP_VERSION, '8.2', '<')) {
+	out(sprintf(_("FreePBX Requires PHP Version 8.2 or Higher, you have: %s"),PHP_VERSION));
 	return false;
 }
 if(\FreePBX::Modules()->checkStatus("sysadmin")) {


### PR DESCRIPTION
# PHP Version Mismatch 

According to the documentation of FreePBX 17, PHP 8.2 is now the minimum required version of PHP to install. However, when reviewing the installation scripts, it's possible to use lower versions, which may cause side effects and differing behaviour.

## Changes

Set PHP 8.2 as the minimum version for install 