### PR TITLE
Fixes #214: Increase padding so buttons are not hidden behind Firefox…

### DIFF
--- a/amp_conf/htdocs/admin/views/login.php
+++ b/amp_conf/htdocs/admin/views/login.php
@@ -14,7 +14,7 @@
 			<input type="password" name="password" class="form-control" value="" placeholder="password" autocomplete="off">
 		</div>
 
-		<div class="" style="text-align:center;padding:10px 0">
+		<div class="" style="text-align:center;padding:50px 0">
 			<button type="button" id="customContinue" class="ui-button ui-corner-all ui-widget btn">Continue</button>
 			<button type="button" id="customCancel" class="ui-button ui-corner-all ui-widget btn">Cancel</button>
 		</div>


### PR DESCRIPTION
The fix makes it so the buttons are not hidden if the warning appears.

<img width="444" height="475" alt="Screenshot from 2025-10-18 20-53-43" src="https://github.com/user-attachments/assets/56747acd-f1e7-4421-8be2-75736b652af0" />