### PR TITLE
Improve System Updates UI with cache, Debian 13 detection, and refres…

### DIFF
--- a/amp_conf/htdocs/admin/libraries/Builtin/SystemUpdates.php
+++ b/amp_conf/htdocs/admin/libraries/Builtin/SystemUpdates.php
@@ -7,17 +7,59 @@ use Symfony\Component\Lock\Store\SemaphoreStore;
 #[\AllowDynamicProperties]
 class SystemUpdates {
 	private $lock;
+	private $freepbx = null;
 	// See framework/hooks/yum-* commands where these files are defined
 	private $lockfile = "/dev/shm/yumwrapper/yum.lock";
 	private $logfile = "/dev/shm/yumwrapper/output.log";
 	//  i18n
 	private $strarr = false; // This is overwritten in __construct
 	private $cli = false;
+	private $hasSysadmin = null; // Cached sysadmin module status
 
 	public function __construct($cli = false) {
 		$this->cli = $cli;
 		// Can't use functions in class definitions
 		$this->strarr = [ "complete" => _("(Complete)"), "unknown" => _("(Unknown)"), "inprogress" => _("(In Progress)"), "yumerror" => _("(YUM Error)"), "error" => _("General Error") ];
+	}
+	
+	/**
+	 * Get FreePBX instance (create once, reuse)
+	 *
+	 * @return \FreePBX
+	 */
+	private function getFreePBX() {
+		if ($this->freepbx === null) {
+			$this->freepbx = \FreePBX::Create();
+		}
+		return $this->freepbx;
+	}
+	
+	/**
+	 * Check if sysadmin module is available (cached)
+	 *
+	 * @return bool
+	 */
+	private function hasSysadminModule() {
+		if ($this->hasSysadmin === null) {
+			try {
+				// Get module info to check if it's actually installed
+				$modinfo = \FreePBX::Modules()->getInfo('sysadmin');
+				// MODULE_STATUS_NOTINSTALLED = 0, so check if status is not 0
+				// Also verify the module entry exists and has a valid status
+				if (!empty($modinfo['sysadmin']) && 
+					isset($modinfo['sysadmin']['status']) && 
+					$modinfo['sysadmin']['status'] != 0) {
+					$this->hasSysadmin = true; 
+				} else {
+					$this->hasSysadmin = false; 
+				}
+			} catch (\Exception $e) {
+				// If there's any error getting module info, assume it's not available
+				dbug('Error checking sysadmin module status: ' . $e->getMessage());
+				$this->hasSysadmin = false;
+			}
+		}
+		return $this->hasSysadmin;
 	}
 
 	public function __destruct() {
@@ -42,6 +84,10 @@ class SystemUpdates {
 			return $this->startSystemUpdate();
 		case 'getsysupdatestatus':
 			return $this->getYumUpdateStatus();
+		case 'getsystemupdatesdata':
+			return $this->getSystemUpdatesData();
+		case 'refreshsystemupdatescache':
+			return $this->refreshSystemUpdatesCache();
 		}
 		throw new \Exception("Unknown action");
 	}
@@ -55,7 +101,7 @@ class SystemUpdates {
 	 */
 	public function canDoSystemUpdates() {
 		return false; // Disabling System update for 17/Debian based system as of now
-		if(!\FreePBX::Modules()->checkStatus('sysadmin')) {
+		if(!$this->hasSysadminModule()) {
 			return false;
 		}
 		\FreePBX::Modules()->loadFunctionsInc('sysadmin');
@@ -355,29 +401,26 @@ class SystemUpdates {
 		return $retarr;
 	}
 
+	/**
+	 * Get pending system updates
+	 * Uses getSystemUpdatesData() internally to avoid duplicate hook calls
+	 *
+	 * @return array|false Array of upgradable packages or false on error
+	 */
 	public function getPendingUpdate() {
 		try {
-			$upgradablePackages=false;
-			if (is_dir("/var/spool/asterisk/incron")) {
-				if (file_exists("/var/spool/asterisk/incron/framework.list-system-updates")) {
-					unlink("/var/spool/asterisk/incron/framework.list-system-updates");
-				}
-				touch("/var/spool/asterisk/incron/framework.list-system-updates");
-				sleep(2);
-			} else {
-				dbug('Incron not configured, unable to manage system updates');
+			// Use getSystemUpdatesData() to get data (it handles cache and hook triggering)
+			$data = $this->getSystemUpdatesData();
+			
+			if ($data && isset($data['status']) && $data['status'] === true) {
+				// Return just the upgradable packages array
+				return isset($data['upgradable']) ? $data['upgradable'] : false;
 			}
-
-			$jsonFilePath = '/var/spool/asterisk/tmp/upgradable_packages.json';
-            if (file_exists($jsonFilePath)) {
-                $jsonContent = file_get_contents($jsonFilePath);
-                $upgradablePackages = json_decode($jsonContent, true);
-			}
+			
+			return false;
 		} catch (\Exception $e) {
 			dbug('Exception occurred: ' . $e->getMessage());
-			$upgradablePackages = false;
-		} finally {
-			return $upgradablePackages;
+			return false;
 		}
 	}
 	/**
@@ -741,7 +784,7 @@ class SystemUpdates {
 
 	public function checkBrokenRpm()
 	{
-		if(!\FreePBX::Modules()->checkStatus('sysadmin')) {
+		if(!$this->hasSysadminModule()) {
 			return false;
 		}
 		// in future add the broken rpm version to this array
@@ -763,6 +806,293 @@ class SystemUpdates {
 				return true;
 			}
 		}
+		return false;
+	}
+
+	/**
+	 * Get system updates data from cache
+	 * Returns cached data if available and not expired (1 hour cache)
+	 * If cache is expired, triggers hook to fetch new data
+	 *
+	 * @return array
+	 */
+	public function getSystemUpdatesData() {
+		try {
+			// Check if sysadmin module is available (cached) - do this first to avoid unnecessary work
+			$hasSysadmin = $this->hasSysadminModule();
+			
+			// If sysadmin module is not installed, return empty data with status true (no error)
+			if (!$hasSysadmin) {
+				return [
+					'status' => false,
+					'upgradable' => [],
+					'held' => [],
+					'security' => [],
+					'repositories' => [],
+					'debian13_risk' => false,
+					'debian13_risk_files' => [],
+					'has_sysadmin' => false
+				];
+			}
+			
+			$freepbx = $this->getFreePBX();
+			$framework = $freepbx->Framework;
+		
+		// Try to get cached data
+		$cached = $framework->getConfig('systemupdates');
+		
+		// Check if we have cached repository data and if it's recent enough (5 minutes for repos)
+		$repoCacheValid = false;
+		if ($cached && is_array($cached) && isset($cached['timestamp'])) {
+			$age = time() - $cached['timestamp'];
+			// Repository data is valid if cache is less than 5 minutes old (300 seconds)
+			// This ensures we get fresh repo checks more frequently than package data
+			$repoCacheValid = ($age < 300);
+		}
+		
+		// If repository cache is stale or doesn't exist, trigger hook to refresh it (only if sysadmin is installed)
+		if (!$repoCacheValid && $hasSysadmin) {
+			$this->triggerSystemUpdatesHook();
+			
+			// Wait a moment for hook to complete, then check cache again
+			$startTime = time();
+			$maxWait = 5; // Wait up to 5 seconds
+			while ((time() - $startTime) < $maxWait) {
+				$cached = $framework->getConfig('systemupdates');
+				if ($cached && is_array($cached) && isset($cached['timestamp'])) {
+					$age = time() - $cached['timestamp'];
+					if ($age < 10) {
+						// Fresh data from hook
+						break;
+					}
+				}
+				usleep(500000); // Wait 0.5 seconds
+			}
+			// Re-read cache after hook
+			$cached = $framework->getConfig('systemupdates');
+		}
+		
+		// Now check if we have valid cached package data (1 hour cache for packages)
+		if ($cached && is_array($cached) && isset($cached['timestamp'])) {
+			$age = time() - $cached['timestamp'];
+			if ($age < 3600) {
+				// Return cached package data with repository data from hook
+				return [
+					'status' => true,
+					'upgradable' => isset($cached['upgradable']) ? $cached['upgradable'] : [],
+					'held' => isset($cached['held']) ? $cached['held'] : [],
+					'security' => isset($cached['security']) ? $cached['security'] : [],
+					'repositories' => isset($cached['repositories']) ? $cached['repositories'] : [],
+					'debian13_risk' => isset($cached['debian13_risk']) ? $cached['debian13_risk'] : false,
+					'debian13_risk_files' => isset($cached['debian13_risk_files']) ? $cached['debian13_risk_files'] : [],
+					'has_sysadmin' => $hasSysadmin,
+					'cache_age' => $age,
+					'last_update' => $cached['timestamp']
+				];
+			}
+		}
+		
+		// Package cache expired or doesn't exist - trigger hook to fetch all data (only if sysadmin is installed)
+		$hookTriggered = false;
+		if ($hasSysadmin) {
+			$hookTriggered = $this->triggerSystemUpdatesHook();
+		}
+		
+		// After triggering hook, check cache again (hook may have updated it)
+		$cached = $framework->getConfig('systemupdates');
+		
+		if ($cached && is_array($cached) && isset($cached['timestamp'])) {
+			// Check if cache was just updated (within last 10 seconds)
+			$age = time() - $cached['timestamp'];
+			if ($age < 10) {
+				// Fresh data from hook
+				return [
+					'status' => true,
+					'upgradable' => isset($cached['upgradable']) ? $cached['upgradable'] : [],
+					'held' => isset($cached['held']) ? $cached['held'] : [],
+					'security' => isset($cached['security']) ? $cached['security'] : [],
+					'repositories' => isset($cached['repositories']) ? $cached['repositories'] : [],
+					'debian13_risk' => isset($cached['debian13_risk']) ? $cached['debian13_risk'] : false,
+					'debian13_risk_files' => isset($cached['debian13_risk_files']) ? $cached['debian13_risk_files'] : [],
+					'has_sysadmin' => $hasSysadmin,
+					'cache_age' => $age,
+					'last_update' => $cached['timestamp']
+				];
+			}
+			
+			// Return stale cached data while waiting
+			return [
+				'status' => true,
+				'upgradable' => isset($cached['upgradable']) ? $cached['upgradable'] : [],
+				'held' => isset($cached['held']) ? $cached['held'] : [],
+				'security' => isset($cached['security']) ? $cached['security'] : [],
+				'repositories' => isset($cached['repositories']) ? $cached['repositories'] : [],
+				'debian13_risk' => isset($cached['debian13_risk']) ? $cached['debian13_risk'] : false,
+				'debian13_risk_files' => isset($cached['debian13_risk_files']) ? $cached['debian13_risk_files'] : [],
+				'has_sysadmin' => $hasSysadmin,
+				'message' => $hookTriggered ? _('Fetching new data... Please refresh in a moment.') : _('Cache expired. Unable to trigger update check.')
+			];
+		}
+		
+		return [
+			'status' => false,
+			'upgradable' => [],
+			'held' => [],
+			'security' => [],
+			'repositories' => [],
+			'debian13_risk' => false,
+			'debian13_risk_files' => [],
+			'has_sysadmin' => $hasSysadmin,
+			'message' => $hookTriggered ? _('Fetching system updates data... Please refresh in a moment.') : _('Unable to fetch system updates data.')
+		];
+		} catch (\Exception $e) {
+			// If there's any error, return error response
+			dbug('Error in getSystemUpdatesData: ' . $e->getMessage());
+			return [
+				'status' => false,
+				'upgradable' => [],
+				'held' => [],
+				'security' => [],
+				'repositories' => [],
+				'debian13_risk' => false,
+				'debian13_risk_files' => [],
+				'has_sysadmin' => false,
+				'message' => _('Error loading system updates data: ') . $e->getMessage()
+			];
+		}
+	}
+	
+	/**
+	 * Force refresh the system updates cache
+	 * Clears the cache and triggers hook to fetch fresh data for both repositories and packages
+	 *
+	 * @return array
+	 */
+	public function refreshSystemUpdatesCache() {
+		$freepbx = $this->getFreePBX();
+		$framework = $freepbx->Framework;
+		
+		// Check if sysadmin module is available (cached)
+		$hasSysadmin = $this->hasSysadminModule();
+		
+		if (!$hasSysadmin) {
+			return [
+				'status' => false,
+				'message' => _('Sysadmin module is not installed. Unable to refresh system updates cache.')
+			];
+		}
+		
+		// Clear the cache
+		$framework->delConfig('systemupdates');
+		
+		// Trigger hook to fetch fresh data
+		$hookTriggered = $this->triggerSystemUpdatesHook();
+		
+		if (!$hookTriggered) {
+			return [
+				'status' => false,
+				'message' => _('Unable to trigger system update check. Please try again.')
+			];
+		}
+		
+		// Wait for hook to complete and update cache
+		$startTime = time();
+		$maxWait = 30; // Maximum 30 seconds to wait
+		
+		while ((time() - $startTime) < $maxWait) {
+			$cached = $framework->getConfig('systemupdates');
+			if ($cached && is_array($cached) && isset($cached['timestamp'])) {
+				$age = time() - $cached['timestamp'];
+				if ($age < 10) {
+					// Fresh data from hook
+					return [
+						'status' => true,
+						'upgradable' => isset($cached['upgradable']) ? $cached['upgradable'] : [],
+						'held' => isset($cached['held']) ? $cached['held'] : [],
+						'security' => isset($cached['security']) ? $cached['security'] : [],
+						'repositories' => isset($cached['repositories']) ? $cached['repositories'] : [],
+					'debian13_risk' => isset($cached['debian13_risk']) ? $cached['debian13_risk'] : false,
+					'debian13_risk_files' => isset($cached['debian13_risk_files']) ? $cached['debian13_risk_files'] : [],
+					'has_sysadmin' => $this->hasSysadminModule(),
+					'message' => _('Cache refreshed successfully.')
+				];
+				}
+			}
+			usleep(500000); // Wait 0.5 seconds before checking again
+		}
+		
+		// Timeout
+		return [
+			'status' => false,
+			'message' => _('Cache refresh timed out. Please try again.')
+		];
+	}
+	
+	/**
+	 * Trigger the system updates hook via incron
+	 * Waits for incron to pick up the file and finish processing
+	 * Similar to how getPendingUpdate() and Hooks::runModuleSystemHook() work
+	 *
+	 * @return bool True if hook was triggered successfully, false otherwise
+	 */
+	private function triggerSystemUpdatesHook() {
+		// Check if sysadmin module is available (cached)
+		if (!$this->hasSysadminModule()) {
+			dbug('Sysadmin module not available, unable to manage system updates');
+			return false;
+		}
+		
+		if (!is_dir("/var/spool/asterisk/incron")) {
+			dbug('Incron not configured, unable to manage system updates');
+			return false;
+		}
+		
+		$hookFile = "/var/spool/asterisk/incron/framework.list-system-updates";
+		
+		// Remove existing hook file if present
+		if (file_exists($hookFile)) {
+			unlink($hookFile);
+		}
+		
+		// Touch the hook file to trigger incron
+		$fh = fopen($hookFile, "w+");
+		if ($fh === false) {
+			dbug("Unable to create hook trigger " . $hookFile);
+			return false;
+		}
+		fclose($fh);
+		
+		// Wait for incron to pick up the file (it will be deleted when processed)
+		// Similar to Hooks::runModuleSystemHook() pattern
+		usleep(500000); // Wait 0.5 seconds
+		
+		if (!file_exists($hookFile)) {
+			// File was picked up by incron, now wait for hook to finish
+			// Check cache timestamp to see if it's been updated
+			$freepbx = $this->getFreePBX();
+			$framework = $freepbx->Framework;
+			
+			$startTime = time();
+			$maxWait = 30; // Maximum 30 seconds to wait
+			
+			while ((time() - $startTime) < $maxWait) {
+				$cached = $framework->getConfig('systemupdates');
+				if ($cached && is_array($cached) && isset($cached['timestamp'])) {
+					$age = time() - $cached['timestamp'];
+					if ($age < 10) {
+						// Cache was just updated
+						return true;
+					}
+				}
+				usleep(500000); // Wait 0.5 seconds before checking again
+			}
+			
+			// Timeout - hook may still be processing
+			return true;
+		}
+		
+		// File wasn't picked up by incron
+		dbug("Hook file '{$hookFile}' was not picked up by Incron. Is it not running?");
 		return false;
 	}
 }

--- a/amp_conf/htdocs/admin/views/module_admin/unable-to-sysupdate.php
+++ b/amp_conf/htdocs/admin/views/module_admin/unable-to-sysupdate.php
@@ -1,46 +1,584 @@
+<?php
+// Get brand name
+$brand = \FreePBX::Config()->get('DASHBOARD_FREEPBX_BRAND');
+
+// Check if sysadmin module is available
+$hasSysadmin = false;
+try {
+	$modinfo = \FreePBX::Modules()->getInfo('sysadmin');
+	if (!empty($modinfo['sysadmin']) && 
+		isset($modinfo['sysadmin']['status']) && 
+		$modinfo['sysadmin']['status'] != 0) {
+		$hasSysadmin = true;
+	}
+} catch (\Exception $e) {
+	$hasSysadmin = false;
+}
+?>
 <div role="tabpanel" class="tab-pane" id="systemupdatestab">
   <div class='container-fluid' style='padding-top: .75em'>
-    <div class='panel panel-default panel-help'>
-      <div class='panel-heading'>
-        <?php
-        echo "<p>"._("Currently, upgrading the operating system through the UI is not available. 
-        Therefore, please proceed with the system upgrade using the Linux command line interface with the following commands: `apt update && apt upgrade`.")."</p>\n";
-        ?>
+    
+    <!-- 1. Warning Section -->
+    <div class='alert alert-warning' style='margin-bottom: 20px; padding: 10px 15px;'>
+      <strong><?php echo _("System updates via the web interface are not currently available."); ?></strong> <?php echo _("Use"); ?> <code>apt update</code> <?php echo _("and"); ?> <code>apt upgrade</code> <?php echo _("on the command line."); ?>
+    </div>
+    
+    <!-- Sysadmin Module Notice -->
+    <div id="sysadmin-notice" class="alert alert-info" style="margin-bottom: 20px; <?php echo $hasSysadmin ? 'display: none;' : ''; ?>">
+      <h4 style='margin-top: 0;'><i class="fa fa-info-circle"></i> <?php echo _("Sysadmin Module Notice"); ?></h4>
+      <p><?php echo _("System update functionality is only supported with Sysadmin module."); ?></p>
+    </div>
+    
+    <!-- Debian 13 Upgrade Risk Warning -->
+    <div id="debian13-warning" class="alert alert-danger" style="margin-bottom: 20px; display: none;">
+      <h4 style='margin-top: 0;'><i class="fa fa-exclamation-circle"></i> <strong><?php echo _("WARNING: Debian 13 Upgrade Risk Detected"); ?></strong></h4>
+      <p><strong><?php echo sprintf(_("%s 17 is supported only on Debian 12."), $brand); ?></strong></p>
+      <p><?php echo sprintf(_("Your repository configuration may allow an upgrade to Debian 13, which is not supported by %s."), $brand); ?></p>
+      <p><?php echo _("To prevent this, ensure your repository files use a specific Debian codename (such as 'bookworm') instead of 'stable'."); ?></p>
+      <p><strong><?php echo _("Affected files:"); ?></strong></p>
+      <ul id="debian13-risk-files-list"></ul>
+      <p><em><?php echo _("Please update your repository configuration to use 'bookworm' instead of 'stable' to prevent unsupported upgrades."); ?></em></p>
+      <div id="debian13-sysadmin-help" style="display: none; margin-top: 15px; padding: 10px; background-color: #fff3cd; border: 1px solid #ffc107; border-radius: 4px;">
+        <p><strong><?php echo _("To automatically prevent Debian 13 upgrades:"); ?></strong></p>
+        <p><?php echo _("Please execute"); ?> <code>fwconsole sa disable-deb-update-v13</code> <?php echo _("to run sysadmin hook"); ?></p>
       </div>
     </div>
-    <h2>Upgradable Packages</h2>
-    <table id="upgradable_packages_table" class="table table-condensed table-striped"
-           data-cache="false"
-           data-show-columns="true"
-           data-show-toggle="true"
-           data-pagination="true"
-           data-search="true"
-           data-toolbar="#toolbar-api-applications"
-           data-toggle="table">
-        <thead>
-            <tr>
-                <th data-field="service"><?php echo _("Service Name"); ?></th>
-                <th data-field="new_version"><?php echo _("New Version"); ?></th>
-                <th data-field="old_version"><?php echo _("Current using Version"); ?></th>
-            </tr>
-        </thead>
-        <tbody>
-            <?php
-              if (isset($systemupdates) && is_array($systemupdates) && count($systemupdates) >0) {
-                    foreach ($systemupdates as $package) {
-                        echo "<tr>";
-                        echo "<td>" . htmlspecialchars($package['service']) . "</td>";
-                        echo "<td>" . htmlspecialchars($package['new_version']) . "</td>";
-                        echo "<td>" . htmlspecialchars($package['old_version']) . "</td>";
-                        echo "</tr>";
-                    }
-                } else {
-                    echo "<tr><td colspan='3'>"._("No upgradable packages found.")."</td></tr>";
-                }
-            ?>
-        </tbody>
-    </table>
+    
+    <div id="systemupdates-loading" style="text-align: center; padding: 20px; <?php echo $hasSysadmin ? '' : 'display: none;'; ?>">
+      <i class="fa fa-spinner fa-spin"></i> <?php echo _("Loading system updates data..."); ?>
+    </div>
+    
+    <div id="systemupdates-content" style="display: none;">
+      
+      <!-- 2. Repository Files Section -->
+      <div class="panel panel-info" style="margin-top: 20px;">
+        <div class="panel-heading" style="cursor: pointer;" data-toggle="collapse" data-target="#repositories-collapse">
+          <h3 class="panel-title">
+            <i class="fa fa-chevron-down" id="repositories-chevron"></i>
+            <?php echo _("Repository Configuration Files"); ?>
+            <span id="repositories-count" class="badge" style="margin-left: 10px;">0</span>
+          </h3>
+        </div>
+        <div id="repositories-collapse" class="panel-collapse collapse">
+          <div class="panel-body">
+            <div id="repositories-list">
+              <p><?php echo _("No repository files found."); ?></p>
+            </div>
+          </div>
+        </div>
+      </div>
+      
+      <!-- 3. System OS Updates Summary Section -->
+      <div class="panel panel-primary" style="margin-top: 20px;">
+        <div class="panel-heading">
+          <h3 class="panel-title">
+            <i class="fa fa-info-circle"></i> <?php echo _("System OS Updates Summary"); ?>
+            <button id="refresh-cache-btn" class="btn btn-sm btn-default pull-right" style="margin-top: -5px;" title="<?php echo _("Refresh cache to get latest data"); ?>">
+              <i class="fa fa-refresh"></i> <span><?php echo _("Refresh Cache"); ?></span>
+            </button>
+          </h3>
+        </div>
+        <div class="panel-body">
+          <div class="row">
+            <div class="col-md-4">
+              <div class="well text-center">
+                <h4><?php echo _("Upgradable Packages"); ?></h4>
+                <h2 id="summary-upgradable-count" style="margin: 0; color: #337ab7;">0</h2>
+              </div>
+            </div>
+            <div class="col-md-4">
+              <div class="well text-center">
+                <h4><?php echo _("Security Updates"); ?></h4>
+                <h2 id="summary-security-count" style="margin: 0; color: #d9534f;">0</h2>
+              </div>
+            </div>
+            <div class="col-md-4">
+              <div class="well text-center">
+                <h4><?php echo _("Held Packages"); ?></h4>
+                <h2 id="summary-held-count" style="margin: 0; color: #f0ad4e;">0</h2>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      
+      <!-- Security Upgradable Packages Section -->
+      <div class="panel panel-danger" style="margin-top: 20px;">
+        <div class="panel-heading" style="cursor: pointer;" data-toggle="collapse" data-target="#security-packages-collapse">
+          <h3 class="panel-title">
+            <i class="fa fa-shield"></i> <i class="fa fa-chevron-down" id="security-chevron"></i>
+            <?php echo _("Security Upgradable Packages"); ?>
+            <span id="security-count" class="badge" style="margin-left: 10px;">0</span>
+          </h3>
+        </div>
+        <div id="security-packages-collapse" class="panel-collapse collapse">
+          <div class="panel-body">
+            <div id="security-packages-list">
+              <p><?php echo _("No security upgradable packages found."); ?></p>
+            </div>
+          </div>
+        </div>
+      </div>
+      
+      <!-- Upgradable Packages Section -->
+      <div class="panel panel-default" style="margin-top: 20px;">
+        <div class="panel-heading" style="cursor: pointer;" data-toggle="collapse" data-target="#upgradable-packages-collapse">
+          <h3 class="panel-title">
+            <i class="fa fa-chevron-down" id="upgradable-chevron"></i>
+            <?php echo _("Upgradable Packages"); ?>
+            <span id="upgradable-count" class="badge" style="margin-left: 10px;">0</span>
+          </h3>
+        </div>
+        <div id="upgradable-packages-collapse" class="panel-collapse collapse">
+          <div class="panel-body">
+            <div id="upgradable-packages-list">
+              <p><?php echo _("No upgradable packages found."); ?></p>
+            </div>
+          </div>
+        </div>
+      </div>
+      
+      <!-- Held Packages Section -->
+      <div class="panel panel-default" style="margin-top: 20px;">
+        <div class="panel-heading" style="cursor: pointer;" data-toggle="collapse" data-target="#held-packages-collapse">
+          <h3 class="panel-title">
+            <i class="fa fa-chevron-down" id="held-chevron"></i>
+            <?php echo _("Held Packages"); ?>
+            <span id="held-count" class="badge" style="margin-left: 10px;">0</span>
+          </h3>
+        </div>
+        <div id="held-packages-collapse" class="panel-collapse collapse">
+          <div class="panel-body">
+            <div class="alert alert-info" style="margin-bottom: 15px;">
+              <p style="margin-bottom: 10px;"><strong><?php echo _("Why are packages held?"); ?></strong></p>
+              <p style="margin-bottom: 10px;"><?php echo _("The freepbx17 and sangoma-pbx17 Debian packages are bootstrap-only components. Their installation process is non-idempotent, and reinstalling them will overwrite critical configuration and may render the system unusable. For this reason, these packages are held to prevent accidental reinstallation."); ?></p>
+              <p style="margin-bottom: 0;"><?php echo sprintf(_("Additionally, nodejs* packages are held to prevent upgrades to newer Node.js versions that may break %s components that depend on a specific Node.js runtime."), $brand); ?></p>
+            </div>
+            <div id="held-packages-list">
+              <p><?php echo _("No held packages found."); ?></p>
+            </div>
+          </div>
+        </div>
+      </div>
+      
+      <div id="systemupdates-message" class="alert alert-info" style="margin-top: 20px; display: none;"></div>
+    </div>
   </div>
 </div>
 
+<script>
+// Load system updates data when tab is clicked
+$(document).ready(function() {
+  var userClickedTab = false;
+  
+  // Track when user actually clicks the tab (not just shown on page load)
+  $('a[href="#systemupdatestab"]').on('click', function(e) {
+    userClickedTab = true;
+  });
+  
+  // Only load when systemupdatestab is shown AND user clicked it
+  $('a[href="#systemupdatestab"]').on('shown.bs.tab', function(e) {
+    // Only load if user actually clicked the tab
+    if (userClickedTab) {
+      <?php if ($hasSysadmin): ?>
+      // Sysadmin is available - load data via AJAX
+      loadSystemUpdatesData();
+      <?php else: ?>
+      // Sysadmin not available - just show the notice, hide loading
+      $('#systemupdates-loading').hide();
+      $('#sysadmin-notice').show();
+      <?php endif; ?>
+      userClickedTab = false; // Reset for next time
+    }
+  });
+  
+  // Handle collapse chevron rotation for all sections
+  $('#repositories-collapse').on('show.bs.collapse', function() {
+    $('#repositories-chevron').removeClass('fa-chevron-down').addClass('fa-chevron-up');
+  });
+  $('#repositories-collapse').on('hide.bs.collapse', function() {
+    $('#repositories-chevron').removeClass('fa-chevron-up').addClass('fa-chevron-down');
+  });
+  
+  $('#security-packages-collapse').on('show.bs.collapse', function() {
+    $('#security-chevron').removeClass('fa-chevron-down').addClass('fa-chevron-up');
+  });
+  $('#security-packages-collapse').on('hide.bs.collapse', function() {
+    $('#security-chevron').removeClass('fa-chevron-up').addClass('fa-chevron-down');
+  });
+  
+  $('#upgradable-packages-collapse').on('show.bs.collapse', function() {
+    $('#upgradable-chevron').removeClass('fa-chevron-down').addClass('fa-chevron-up');
+  });
+  $('#upgradable-packages-collapse').on('hide.bs.collapse', function() {
+    $('#upgradable-chevron').removeClass('fa-chevron-up').addClass('fa-chevron-down');
+  });
+  
+  $('#held-packages-collapse').on('show.bs.collapse', function() {
+    $('#held-chevron').removeClass('fa-chevron-down').addClass('fa-chevron-up');
+  });
+  $('#held-packages-collapse').on('hide.bs.collapse', function() {
+    $('#held-chevron').removeClass('fa-chevron-up').addClass('fa-chevron-down');
+  });
+  
+  // Handle refresh cache button
+  $('#refresh-cache-btn').on('click', function() {
+    refreshSystemUpdatesCache();
+  });
+  
+});
 
+function refreshSystemUpdatesCache() {
+  var $btn = $('#refresh-cache-btn');
+  var $icon = $btn.find('i');
+  var originalHtml = $btn.html();
+  
+  // Disable button and show loading state
+  $btn.prop('disabled', true);
+  $icon.removeClass('fa-refresh').addClass('fa-spinner fa-spin');
+  $btn.find('span').text('<?php echo _("Refreshing..."); ?>');
+  
+  $.ajax({
+    url: window.ajaxurl,
+    data: { module: "framework", command: "sysupdate", action: "refreshsystemupdatescache" },
+    success: function(response) {
+      if (response.status === true) {
+        // Cache refreshed, now reload the data
+        loadSystemUpdatesData();
+        // Show success message briefly
+        $('#systemupdates-message').text(response.message || _("Cache refreshed successfully.")).removeClass('alert-danger alert-warning').addClass('alert-success').show();
+        setTimeout(function() {
+          $('#systemupdates-message').fadeOut();
+        }, 3000);
+      } else {
+        $('#systemupdates-message').text(response.message || _("Failed to refresh cache.")).removeClass('alert-success alert-info').addClass('alert-danger').show();
+      }
+    },
+    error: function(xhr, status, error) {
+      $('#systemupdates-message').text(_("Error refreshing cache.")).removeClass('alert-success alert-info').addClass('alert-danger').show();
+    },
+    complete: function() {
+      // Re-enable button and restore original state
+      $btn.prop('disabled', false);
+      $icon.removeClass('fa-spinner fa-spin').addClass('fa-refresh');
+      $btn.find('span').text('<?php echo _("Refresh Cache"); ?>');
+    }
+  });
+}
+
+function loadSystemUpdatesData() {
+  $.ajax({
+    url: window.ajaxurl,
+    data: { module: "framework", command: "sysupdate", action: "getsystemupdatesdata" },
+    success: function(response) {
+      $('#systemupdates-loading').hide();
+      $('#systemupdates-content').show();
+      
+      if (response.status === true) {
+        // Show sysadmin notice if module is not present
+        if (response.has_sysadmin === false) {
+          $('#sysadmin-notice').show();
+          // Hide all content sections when sysadmin is not installed
+          $('#systemupdates-content').hide();
+          // Hide any error messages
+          $('#systemupdates-message').hide();
+          return;
+        } else {
+          $('#sysadmin-notice').hide();
+          $('#systemupdates-content').show();
+        }
+        
+        // Check for Debian 13 risk and show warning
+        if (response.debian13_risk === true) {
+          $('#debian13-warning').show();
+          var riskFilesList = $('#debian13-risk-files-list');
+          riskFilesList.empty();
+          if (response.debian13_risk_files && response.debian13_risk_files.length > 0) {
+            response.debian13_risk_files.forEach(function(file) {
+              riskFilesList.append('<li><code>' + escapeHtml(file) + '</code></li>');
+            });
+          }
+          // Show sysadmin help text only if sysadmin module is available
+          if (response.has_sysadmin === true) {
+            $('#debian13-sysadmin-help').show();
+          } else {
+            $('#debian13-sysadmin-help').hide();
+          }
+        } else {
+          $('#debian13-warning').hide();
+          $('#debian13-sysadmin-help').hide();
+        }
+        
+        // Update summary counts
+        var upgradableCount = (response.upgradable || []).length;
+        var securityCount = (response.security || []).length;
+        var heldCount = (response.held || []).length;
+        
+        $('#summary-upgradable-count').text(upgradableCount);
+        $('#summary-security-count').text(securityCount);
+        $('#summary-held-count').text(heldCount);
+        
+        // Display all sections
+        displayRepositories(response.repositories || {});
+        displaySecurityPackages(response.security || []);
+        displayUpgradablePackages(response.upgradable || []);
+        displayHeldPackages(response.held || []);
+        
+        // Hide message if data loaded successfully
+        $('#systemupdates-message').hide();
+      } else {
+        // Only show error if sysadmin is installed (otherwise we already handled it above)
+        if (response.has_sysadmin !== false) {
+          $('#systemupdates-message').text(response.message || _("Unable to load system updates data.")).removeClass('alert-info').addClass('alert-warning').show();
+        }
+      }
+    },
+    error: function(xhr, status, error) {
+      $('#systemupdates-loading').hide();
+      $('#systemupdates-content').show();
+      $('#systemupdates-message').text(_("Error loading system updates data.")).removeClass('alert-info').addClass('alert-danger').show();
+    }
+  });
+}
+
+function displayRepositories(repositories) {
+  var count = Object.keys(repositories).length;
+  $('#repositories-count').text(count);
+  
+  if (count === 0) {
+    $('#repositories-list').html('<p><?php echo _("No repository files found."); ?></p>');
+    return;
+  }
+  
+  var html = '';
+  for (var filepath in repositories) {
+    if (repositories.hasOwnProperty(filepath)) {
+      html += '<div style="margin-bottom: 20px;">';
+      html += '<h5><strong>' + escapeHtml(filepath) + '</strong></h5>';
+      html += '<pre style="background-color: #f5f5f5; padding: 10px; border: 1px solid #ddd; border-radius: 4px; max-height: 300px; overflow-y: auto;">' + escapeHtml(repositories[filepath]) + '</pre>';
+      html += '</div>';
+    }
+  }
+  
+  $('#repositories-list').html(html);
+}
+
+function displaySecurityPackages(packages) {
+  var count = packages.length;
+  $('#security-count').text(count);
+  
+  if (count === 0) {
+    $('#security-packages-list').html('<p><?php echo _("No security upgradable packages found."); ?></p>');
+    return;
+  }
+  
+  var html = '<table class="table table-condensed table-striped table-bordered">';
+  html += '<thead><tr><th><?php echo _("Package Name"); ?></th><th><?php echo _("New Version"); ?></th><th><?php echo _("Current Version"); ?></th><th><?php echo _("Repository"); ?></th></tr></thead>';
+  html += '<tbody>';
+  
+  for (var i = 0; i < packages.length; i++) {
+    var pkg = packages[i];
+    html += '<tr>';
+    html += '<td><strong>' + escapeHtml(pkg.name || '') + '</strong></td>';
+    html += '<td><span class="label label-danger">' + escapeHtml(pkg.new_version || '') + '</span></td>';
+    html += '<td>' + escapeHtml(pkg.old_version || '') + '</td>';
+    html += '<td><code>' + escapeHtml(pkg.repository || '') + '</code></td>';
+    html += '</tr>';
+  }
+  
+  html += '</tbody></table>';
+  $('#security-packages-list').html(html);
+}
+
+function displayUpgradablePackages(packages) {
+  var count = packages.length;
+  $('#upgradable-count').text(count);
+  
+  if (count === 0) {
+    $('#upgradable-packages-list').html('<p><?php echo _("No upgradable packages found."); ?></p>');
+    return;
+  }
+  
+  var html = '<table class="table table-condensed table-striped table-bordered">';
+  html += '<thead><tr><th><?php echo _("Package Name"); ?></th><th><?php echo _("New Version"); ?></th><th><?php echo _("Current Version"); ?></th></tr></thead>';
+  html += '<tbody>';
+  
+  for (var i = 0; i < packages.length; i++) {
+    var pkg = packages[i];
+    html += '<tr>';
+    html += '<td>' + escapeHtml(pkg.name || '') + '</td>';
+    html += '<td>' + escapeHtml(pkg.new_version || '') + '</td>';
+    html += '<td>' + escapeHtml(pkg.old_version || '') + '</td>';
+    html += '</tr>';
+  }
+  
+  html += '</tbody></table>';
+  $('#upgradable-packages-list').html(html);
+}
+
+function displayHeldPackages(packages) {
+  var count = packages.length;
+  $('#held-count').text(count);
+  
+  if (count === 0) {
+    $('#held-packages-list').html('<p><?php echo _("No held packages found."); ?></p>');
+    return;
+  }
+  
+  // Group packages by similar patterns
+  var regularPackages = [];
+  var similarGroups = {};
+  
+  for (var i = 0; i < packages.length; i++) {
+    var pkg = packages[i];
+    var pkgName = pkg.name || '';
+    
+    // Pattern 1: node-* packages -> group as "nodejs*"
+    if (pkgName.indexOf('node-') === 0) {
+      var groupKey = 'nodejs*';
+      if (!similarGroups[groupKey]) {
+        similarGroups[groupKey] = [];
+      }
+      similarGroups[groupKey].push(pkg);
+    }
+    // Pattern 2: lib*-* packages (e.g., libfoo1, libfoo-dev)
+    else if (pkgName.indexOf('lib') === 0) {
+      // Extract base name (remove version numbers and common suffixes)
+      var baseName = pkgName.replace(/^lib/, '').replace(/[-_]\d+.*$/, '').replace(/-\w+$/, '');
+      if (baseName.length >= 2) {
+        var groupKey = 'lib' + baseName + '*';
+        if (!similarGroups[groupKey]) {
+          similarGroups[groupKey] = [];
+        }
+        similarGroups[groupKey].push(pkg);
+      } else {
+        regularPackages.push(pkg);
+      }
+    }
+    // Pattern 3: Packages with same prefix (e.g., python3-*, php7-*)
+    else {
+      var parts = pkgName.split('-');
+      if (parts.length >= 2 && parts[0].length >= 3) {
+        var prefix = parts[0];
+        var groupKey = prefix + '*';
+        if (!similarGroups[groupKey]) {
+          similarGroups[groupKey] = [];
+        }
+        similarGroups[groupKey].push(pkg);
+      } else {
+        regularPackages.push(pkg);
+      }
+    }
+  }
+  
+  // Filter similar groups to only show those with 2+ packages
+  var groupsWithMultiple = {};
+  for (var groupKey in similarGroups) {
+    if (similarGroups[groupKey].length > 1) {
+      groupsWithMultiple[groupKey] = similarGroups[groupKey];
+    } else {
+      // If only one package in group, move it back to regular
+      regularPackages.push(similarGroups[groupKey][0]);
+    }
+  }
+  
+  // Build table with regular packages and grouped similar packages
+  var html = '<table class="table table-condensed table-striped table-bordered">';
+  html += '<thead><tr><th><?php echo _("Package Name"); ?></th><th><?php echo _("Version"); ?></th></tr></thead>';
+  html += '<tbody>';
+  
+  // Display regular packages first
+  for (var i = 0; i < regularPackages.length; i++) {
+    var pkg = regularPackages[i];
+    html += '<tr>';
+    html += '<td>' + escapeHtml(pkg.name || '') + '</td>';
+    html += '<td>' + escapeHtml(pkg.version || '') + '</td>';
+    html += '</tr>';
+  }
+  
+  // Display similar package groups as expandable rows
+  for (var groupKey in groupsWithMultiple) {
+    var groupId = 'similar-group-' + escapeHtml(groupKey).replace(/[^a-zA-Z0-9*]/g, '-');
+    var groupPackages = groupsWithMultiple[groupKey];
+    
+    // Main row with group name (clickable to expand)
+    html += '<tr class="info expandable-group-row" style="cursor: pointer;" data-group-id="' + groupId + '">';
+    html += '<td>';
+    html += '<i class="fa fa-chevron-right similar-chevron-' + groupId + '" style="margin-right: 5px;"></i>';
+    html += '<strong>' + escapeHtml(groupKey) + '</strong>';
+    html += ' <span class="badge">' + groupPackages.length + '</span>';
+    html += '</td>';
+    html += '<td><?php echo _("Click to expand"); ?></td>';
+    html += '</tr>';
+    
+    // Collapsible row with individual packages
+    html += '<tr class="similar-packages-detail" id="' + groupId + '" style="display: none;">';
+    html += '<td colspan="2" style="padding: 0; border-top: none;">';
+    html += '<div style="padding: 10px; background-color: #f9f9f9;">';
+    html += '<table class="table table-condensed table-bordered" style="margin-bottom: 0;">';
+    html += '<thead><tr><th style="width: 70%;"><?php echo _("Package Name"); ?></th><th><?php echo _("Version"); ?></th></tr></thead>';
+    html += '<tbody>';
+    
+    for (var j = 0; j < groupPackages.length; j++) {
+      var pkg = groupPackages[j];
+      html += '<tr>';
+      html += '<td style="padding-left: 30px;">' + escapeHtml(pkg.name || '') + '</td>';
+      html += '<td>' + escapeHtml(pkg.version || '') + '</td>';
+      html += '</tr>';
+    }
+    
+    html += '</tbody></table>';
+    html += '</div>';
+    html += '</td>';
+    html += '</tr>';
+  }
+  
+  html += '</tbody></table>';
+  $('#held-packages-list').html(html);
+  
+  // Add click handlers for expandable rows - use direct binding after HTML is inserted
+  // Use delegated event handler that works with dynamically added content
+  $('#held-packages-list').off('click', '.expandable-group-row');
+  $('#held-packages-list').on('click', '.expandable-group-row', function(e) {
+    e.preventDefault();
+    e.stopPropagation();
+    
+    var $row = $(this);
+    var groupId = $row.data('group-id');
+    
+    // Use attribute selector to avoid issues with special characters in ID
+    var $detailRow = $('#held-packages-list [id="' + groupId.replace(/"/g, '\\"') + '"]');
+    
+    // For chevron, we need to escape special characters for class selector
+    // The chevron class is: similar-chevron-{groupId}
+    // Find it within the clicked row to avoid selector issues
+    var $chevron = $row.find('i[class*="similar-chevron-"]');
+    
+    if ($detailRow.length === 0) {
+      console.error('Detail row not found for group:', groupId);
+      return false;
+    }
+    
+    if ($detailRow.is(':visible')) {
+      $detailRow.slideUp(200);
+      $chevron.removeClass('fa-chevron-down').addClass('fa-chevron-right');
+    } else {
+      $detailRow.slideDown(200);
+      $chevron.removeClass('fa-chevron-right').addClass('fa-chevron-down');
+    }
+    
+    return false;
+  });
+}
+
+function escapeHtml(text) {
+  var map = {
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#039;'
+  };
+  return text ? text.replace(/[&<>"']/g, function(m) { return map[m]; }) : '';
+}
+</script>

--- a/hooks/list-system-updates
+++ b/hooks/list-system-updates
@@ -1,45 +1,205 @@
 #!/usr/bin/php
 <?php
+// Set timeout to prevent hanging
+set_time_limit(60);
+ini_set('max_execution_time', 60);
+
 error_reporting(E_ALL);
-require '/usr/lib/sysadmin/includes.php';
-// Execute the command and get the output
-$output = shell_exec('sudo apt list --upgradable');
-// Check if the output is not empty
-if ($output) {
-    // Initialize an array to store the parsed data
-    $upgradablePackages = [];
-    // Split the output into lines
+
+// Try to load sysadmin includes (may not exist on all systems)
+if (file_exists('/usr/lib/sysadmin/includes.php')) {
+    require '/usr/lib/sysadmin/includes.php';
+}
+
+// Load FreePBX config
+if (!file_exists('/etc/freepbx.conf')) {
+    echo "Error: /etc/freepbx.conf not found\n";
+    exit(1);
+}
+
+include_once '/etc/freepbx.conf';
+
+// Get upgradable packages - run apt list only ONCE and parse for both regular and security
+$upgradablePackages = [];
+$securityPackages = [];
+$output = shell_exec('apt list --upgradable 2>/dev/null');
+if ($output && is_string($output)) {
     $lines = explode("\n", $output);
-    // Process each line
     foreach ($lines as $line) {
-        // Use regular expression to parse the line
-        if (preg_match('/^(\S+)\/\S+\s+(\S+)\s+\S+\s+\[upgradable from: (\S+)\]$/', $line, $matches)) {
-            $packageName = $matches[1] ?? '';
+        // Skip empty lines and header line
+        if (empty($line) || strpos($line, 'Listing...') !== false) {
+            continue;
+        }
+        // Parse line format: package/arch version repository [upgradable from: old_version]
+        if (preg_match('/^(\S+)\/\S+\s+(\S+)\s+(\S+)\s+\[upgradable from: (\S+)\]$/', $line, $matches)) {
+            $packageName = isset($matches[1]) ? $matches[1] : '';
+            $repository = isset($matches[3]) ? $matches[3] : '';
+            
+            // Skip FreePBX/Sangoma packages
             if (
-                strpos($packageName, 'freepbx17') === false &&
-                strpos($packageName, 'sangoma-pbx17') === false &&
-                $packageName !== 'nodejs' &&
-                strpos($packageName, 'node-') !== 0 
+                empty($packageName) ||
+                strpos($packageName, 'freepbx17') !== false ||
+                strpos($packageName, 'sangoma-pbx17') !== false ||
+                $packageName === 'nodejs' ||
+                strpos($packageName, 'node-') === 0 
             ) {
-                $upgradablePackages[] = [
-                    'service' => $matches[1],
-                    'new_version' => $matches[2],
-                    'old_version' => $matches[3],
-                ];
+                continue;
+            }
+            
+            $packageData = [
+                'name' => $matches[1],
+                'new_version' => isset($matches[2]) ? $matches[2] : '',
+                'old_version' => isset($matches[4]) ? $matches[4] : '',
+            ];
+            
+            // Check if it's a security package
+            if (stripos($repository, 'security') !== false || stripos($repository, '-security') !== false) {
+                $packageData['repository'] = $repository;
+                $securityPackages[] = $packageData;
+            }
+            
+            // Add to regular upgradable packages
+            $upgradablePackages[] = $packageData;
+        }
+    }
+}
+
+// Get held packages - optimized to get all versions in one command
+$heldPackages = [];
+$output = shell_exec('apt-mark showhold 2>/dev/null');
+if ($output && is_string($output)) {
+    $lines = explode("\n", $output);
+    $packageNames = [];
+    foreach ($lines as $line) {
+        // Handle null/empty values safely
+        $line = is_string($line) ? trim($line) : '';
+        if (!empty($line)) {
+            $packageNames[] = $line;
+        }
+    }
+    
+    // Get all versions in one dpkg-query command instead of one per package
+    if (!empty($packageNames)) {
+        $escapedNames = array_map('escapeshellarg', $packageNames);
+        $namesList = implode(' ', $escapedNames);
+        $versionOutput = shell_exec("dpkg-query -W -f='\${Package}\t\${Version}\n' $namesList 2>/dev/null");
+        
+        // Parse version output into associative array
+        $versions = [];
+        if ($versionOutput && is_string($versionOutput)) {
+            $versionLines = explode("\n", $versionOutput);
+            foreach ($versionLines as $versionLine) {
+                $parts = explode("\t", trim($versionLine));
+                if (count($parts) === 2) {
+                    $versions[$parts[0]] = $parts[1];
+                }
+            }
+        }
+        
+        // Build held packages array
+        foreach ($packageNames as $pkgName) {
+            $heldPackages[] = [
+                'name' => $pkgName,
+                'version' => isset($versions[$pkgName]) ? $versions[$pkgName] : 'Unknown'
+            ];
+        }
+    }
+}
+
+// Get repository files and check for Debian 13 upgrade risk
+$repoFiles = [];
+$debian13Risk = false;
+$debian13RiskFiles = [];
+$supportedCodenames = ['bookworm', 'bullseye', 'buster', 'stretch', 'jessie', 'wheezy'];
+
+// Function to check if a repository line is risky
+function checkRepoLineRisk($line, $supportedCodenames) {
+    $line = trim($line);
+    // Skip comments and empty lines
+    if (empty($line) || $line[0] === '#') {
+        return false;
+    }
+    // Check if line contains "stable" or "trixie" (Debian 13)
+    if (preg_match('/\b(stable|trixie)\b/i', $line)) {
+        // Check if the same line also contains a supported codename
+        $hasSupportedCodename = false;
+        foreach ($supportedCodenames as $codename) {
+            if (stripos($line, $codename) !== false) {
+                $hasSupportedCodename = true;
+                break;
+            }
+        }
+        // If it has "stable" or "trixie" but no supported codename, it's risky
+        return !$hasSupportedCodename;
+    }
+    return false;
+}
+
+// Main sources.list
+if (file_exists('/etc/apt/sources.list')) {
+    $content = file_get_contents('/etc/apt/sources.list');
+    if ($content !== false) {
+        $repoFiles['/etc/apt/sources.list'] = $content;
+        $lines = explode("\n", $content);
+        foreach ($lines as $line) {
+            if (checkRepoLineRisk($line, $supportedCodenames)) {
+                $debian13Risk = true;
+                if (!in_array('/etc/apt/sources.list', $debian13RiskFiles)) {
+                    $debian13RiskFiles[] = '/etc/apt/sources.list';
+                }
+                break;
             }
         }
     }
-    // Define the file path
-    $filePath = '/var/spool/asterisk/tmp/upgradable_packages.json';
-    // Convert the parsed data to a JSON string
-    $jsonContent = json_encode($upgradablePackages, JSON_PRETTY_PRINT);
-    // Save the JSON content to the file
-    if (file_put_contents($filePath, $jsonContent) !== false) {
-        echo "Data successfully saved to {$filePath}";
-    } else {
-        echo "Failed to save data to {$filePath}";
+}
+// Sources in sources.list.d directory
+if (is_dir('/etc/apt/sources.list.d')) {
+    $files = glob('/etc/apt/sources.list.d/*.list');
+    if ($files) {
+        foreach ($files as $file) {
+            $content = file_get_contents($file);
+            if ($content !== false) {
+                $repoFiles[$file] = $content;
+                $lines = explode("\n", $content);
+                foreach ($lines as $line) {
+                    if (checkRepoLineRisk($line, $supportedCodenames)) {
+                        $debian13Risk = true;
+                        if (!in_array($file, $debian13RiskFiles)) {
+                            $debian13RiskFiles[] = $file;
+                        }
+                        break;
+                    }
+                }
+            }
+        }
     }
-} else {
-    echo "No upgradable packages found or failed to execute the command.";
+}
+
+// Write data to cache
+try {
+    $freepbx = \FreePBX::Create();
+    $framework = $freepbx->Framework;
+    
+    $data = [
+        'upgradable' => $upgradablePackages,
+        'held' => $heldPackages,
+        'security' => $securityPackages,
+        'repositories' => $repoFiles,
+        'debian13_risk' => $debian13Risk,
+        'debian13_risk_files' => $debian13RiskFiles,
+        'timestamp' => time()
+    ];
+    
+    // Store in cache
+    $framework->setConfig('systemupdates', $data);
+    
+    echo "System updates data written to cache successfully\n";
+    exit(0);
+} catch (\Exception $e) {
+    echo "Error writing system updates data: " . $e->getMessage() . "\n";
+    exit(1);
+} catch (\Throwable $e) {
+    echo "Fatal error: " . $e->getMessage() . "\n";
+    exit(1);
 }
 


### PR DESCRIPTION
…h button

- Restore cache-based system updates (1hr packages, 5min repos)
- Add UI sections: warnings, repository files, summary dashboard, security packages
- Detect and warn about Debian 13 upgrade risk from "stable" repos
- Add manual cache refresh button for repositories and packages