### PR TITLE
Update PHP command to full path in amportal script

### DIFF
--- a/amp_conf/bin/amportal
+++ b/amp_conf/bin/amportal
@@ -5,7 +5,7 @@
 
 # get settings from db/config file
 if [ -e "/etc/freepbx.conf" ]; then        # Check if file exists.
-	php -v > /dev/null 2>&1
+	/usr/bin/php -v > /dev/null 2>&1
 	if [ $? -eq 0 ]; then
   		`php -r '
 		$bootstrap_settings["freepbx_auth"] = false;


### PR DESCRIPTION
The php command when used to check for the version installed used relative path notation and thus would mean the script would use the executors path variable to find the php binary. By changing it to the full path; it will now ensure that only the right php binary is executed.

This was smth raised in a security advisory but that I had closed as I determined it was not worth having a CVE for due to the abuse context and that it was a better spend of resources to simply fix directly : ) 