### PR TITLE
typo in page.modules.php, non-existing variable

### DIFF
--- a/amp_conf/htdocs/admin/page.modules.php
+++ b/amp_conf/htdocs/admin/page.modules.php
@@ -640,7 +640,7 @@ switch ($action) {
 					$skipaction = true;
 					$issues = true;
 					$errorstext[] = sprintf(_("%s cannot be enabled: %s Please try again after the dependencies have been installed."),
-						"<strong>".$modules[$module]['name']."</strong>",'<strong><ul><li>'.implode('</li><li>',$dependserrors).'</li></ul></strong>');
+						"<strong>".$modules[$module]['name']."</strong>",'<strong><ul><li>'.implode('</li><li>',$dependerrors).'</li></ul></strong>');
 				}
 				if ($conflicterrors['breaking'] && is_array($conflicterrors['issues'][$modules[$module]['name']]) && !empty($conflicterrors['issues'][$modules[$module]['name']])) {
 					$skipaction = true;


### PR DESCRIPTION
<img width="1471" height="1029" alt="Screenshot From 2025-12-20 18-50-38" src="https://github.com/user-attachments/assets/003a7797-2b38-4414-8b52-0c436e657098" />
