### PR TITLE
fix(job): scope lock to --run, fix exit code, remove dead code

### DIFF
--- a/amp_conf/htdocs/admin/libraries/Console/Job.class.php
+++ b/amp_conf/htdocs/admin/libraries/Console/Job.class.php
@@ -74,21 +74,20 @@ class Job extends Command {
 		}
 
 		// Acquire lock only for --run to prevent concurrent job execution.
-		// Non-destructive operations (--list, --enable, --disable) do not
-		// need mutual exclusion and should not be blocked by a running job.
-		if (!$this->lock()) {
-			$output->writeln('<error>The command is already running in another process.</error>');
-			return 1;
-		}
+		// Non-destructive operations (--list, --enable, --disable, help)
+		// do not need mutual exclusion and should not be blocked.
+		if($input->hasParameterOption('--run')) {
+			if (!$this->lock()) {
+				$output->writeln('<error>The command is already running in another process.</error>');
+				return 1;
+			}
 
-		if($input->hasParameterOption('--run') && is_null($input->getOption('run'))) {
-			//run all
-			$this->runJobs($this->registerTasks($this->findAllJobs()));
-			return 0;
-		}
-
-		if($input->getOption('run')) {
-			$this->runJobs($this->registerTasks($this->findAllJobs([$input->getOption('run')])));
+			if(is_null($input->getOption('run'))) {
+				//run all
+				$this->runJobs($this->registerTasks($this->findAllJobs()));
+			} else {
+				$this->runJobs($this->registerTasks($this->findAllJobs([$input->getOption('run')])));
+			}
 			return 0;
 		}
 

--- a/amp_conf/htdocs/admin/libraries/Console/Job.class.php
+++ b/amp_conf/htdocs/admin/libraries/Console/Job.class.php
@@ -39,11 +39,6 @@ class Job extends Command {
 		$this->output = $output;
 		$this->input = $input;
 
-		if (!$this->lock()) {
-			$output->writeln('The command is already running in another process.');
-			return 0;
-		}
-
 		if($input->getOption('force')) {
 			$this->force = true;
 		}
@@ -55,22 +50,6 @@ class Job extends Command {
 
 		if($input->getOption('disable')) {
 			$this->enableJob($input->getOption('disable'), false);
-			return 0;
-		}
-
-		if($input->getOption('disable')) {
-			$this->runJobs($this->registerTasks($this->findAllJobs([$input->getOption('run')])));
-			return 0;
-		}
-
-		if($input->hasParameterOption('--run') && is_null($input->getOption('run'))) {
-			//run all
-			$this->runJobs($this->registerTasks($this->findAllJobs()));
-			return 0;
-		}
-
-		if($input->getOption('run')) {
-			$this->runJobs($this->registerTasks($this->findAllJobs([$input->getOption('run')])));
 			return 0;
 		}
 
@@ -91,6 +70,25 @@ class Job extends Command {
 			}
 			$table->setRows($rows);
 			$table->render();
+			return 0;
+		}
+
+		// Acquire lock only for --run to prevent concurrent job execution.
+		// Non-destructive operations (--list, --enable, --disable) do not
+		// need mutual exclusion and should not be blocked by a running job.
+		if (!$this->lock()) {
+			$output->writeln('<error>The command is already running in another process.</error>');
+			return 1;
+		}
+
+		if($input->hasParameterOption('--run') && is_null($input->getOption('run'))) {
+			//run all
+			$this->runJobs($this->registerTasks($this->findAllJobs()));
+			return 0;
+		}
+
+		if($input->getOption('run')) {
+			$this->runJobs($this->registerTasks($this->findAllJobs([$input->getOption('run')])));
 			return 0;
 		}
 


### PR DESCRIPTION
## Summary

Three issues in `fwconsole job` that combine to silently prevent time-sensitive jobs (like time condition BLF updates) from executing.

### 1. Lock scope too broad

The `LockableTrait` lock is acquired at the top of `execute()`, blocking **all** operations — including `--list`, `--enable`, and `--disable` — when a `--run` is already in progress. These non-destructive operations do not modify job state or interfere with running jobs.

**Fix:** Move the lock to immediately before the `--run` dispatch. `--list`, `--enable`, and `--disable` now execute without contention.

### 2. Lock contention returns exit code 0

When a second `fwconsole job --run` cannot acquire the lock, it returns `0` (success). Cron, scripts, and monitoring cannot distinguish a successful run from a completely skipped one.

**Fix:** Return `1` (failure) and wrap the message in `<error>` tags for console visibility.

### 3. Dead code block

Lines 61–64 contain a duplicate `if(\$input->getOption('disable'))` check that is identical to the block at lines 56–59 — making it unreachable. The body references `\$input->getOption('run')` suggesting it was intended as the `--run` dispatch but was never corrected.

**Fix:** Remove the dead block.

### Impact

On busy PBXact/FreePBX systems with 27+ registered jobs, a single slow job (calendar sync, firewall update, SangomaConnect keepalive) can hold the process-wide lock past the 60-second cron interval. The next `fwconsole job --run` silently exits with code 0, skipping all jobs including time-sensitive ones like the timeconditions `schedtc` job that updates BLF hint states.

With the lock scoped to `--run` only, administrators can still query and manage jobs (`--list`, `--enable`, `--disable`) during a long-running job execution.

### Environment

- FreePBX 17 / PBXact 17
- Symfony Console 6.2.x (`LockableTrait`)
- PHP 8.1+ (Debian 12)

### Related

- Companion PRs for the downstream timeconditions crash: https://github.com/FreePBX/timeconditions/pull/23 and https://github.com/FreePBX/calendar/pull/31
- Community thread (same symptom chain): https://community.freepbx.org/t/freepbx-bug-blf-subscriptions/106007

---

*Discovered during fleet maintenance by Aaron Salsitz (Master Bitherder) at [ICCI, LLC](https://icci.com). Analysis and fix developed with [Claude Code](https://claude.ai/code).*