### PR TITLE
Improve AAC codec detection

### DIFF
--- a/amp_conf/htdocs/admin/libraries/media/Media/Driver/Drivers/FfmpegShell.php
+++ b/amp_conf/htdocs/admin/libraries/media/Media/Driver/Drivers/FfmpegShell.php
@@ -35,10 +35,10 @@ class FfmpegShell extends \Media\Driver\Driver {
 	 */
 	private static function hasAAC() {
 		$loc = fpbx_which("ffmpeg");
-		$process = \freepbx_get_process_obj($loc.' -version');
+		$process = \freepbx_get_process_obj($loc.' -loglevel quiet -decoders');
 		$process->mustRun();
 		$output = $process->getOutput();
-		return !!preg_match_all('/enable-libfdk-aac\s/', $output);
+		return !!preg_match_all('/A\.{4}D aac/', $output);
 	}
 
 	public static function supportedCodecs(&$formats) {


### PR DESCRIPTION
The old test fails for some version of the ffmpeg binary : 

- `ffmpeg -version |grep enable-libfdk-aac` will not work for the debian ffmpeg binary
- `ffmpeg -decoders |grep 'A....D aac'` will find if ffmpeg is able to decode AAC with both binaries.

No check if ffmpeg can encode AAC. If it's necessary, it's easy to add it : `ffmpeg -encoders |grep 'A..... aac'`

Adding `-loglevel quiet` makes ffmpeg generates less (useless in this case) logs.