### PR TITLE
Fix POSIX redirection in Asterisk stop command

### DIFF
--- a/amp_conf/htdocs/admin/libraries/Console/Stop.class.php
+++ b/amp_conf/htdocs/admin/libraries/Console/Stop.class.php
@@ -231,7 +231,7 @@ class Stop extends Command {
 				$sastbin = '/usr/bin/env killall safe_asterisk > /dev/null 2>&1';
 				exec($sastbin);
 			case "gracefully":
-				$astbin = '/usr/bin/env asterisk -rx "core stop ' . $method .'" &>/dev/null &';
+				$astbin = '/usr/bin/env asterisk -rx "core stop ' . $method .'" >/dev/null 2>&1 &';
 				shell_exec($astbin);
 			break;
 		}


### PR DESCRIPTION
## Summary

Use POSIX-compatible output redirection for the background Asterisk stop command in `Console/Stop.class.php`.

## Why

`Stop.class.php` launches the Asterisk CLI through `shell_exec()`. On Debian 12, `/bin/sh` is `dash`, while `&>` is Bash-specific syntax.

The current command uses:

`asterisk -rx "core stop ..." &>/dev/null &`

Change it to the POSIX-compatible form:

`asterisk -rx "core stop ..." >/dev/null 2>&1 &`

This avoids relying on Bash-specific redirection in a command executed through the system shell.

## Validation

- `php -l amp_conf/htdocs/admin/libraries/Console/Stop.class.php` — PASS
- `git diff --check` — PASS
- Exactly one file changed
- Exactly one insertion / one deletion

## Scope

This PR fixes only the shell-redirection defect in `Stop.class.php`.

It does not claim to fix the separate DPMA `res_digium_phone.so` unload hang described in the shutdown investigation.

Related context:
https://github.com/FreePBX/issue-tracker/issues/439
